### PR TITLE
Add workspace tables (QListWidgets)

### DIFF
--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -66,6 +66,7 @@ class HistogramModel:
         self.error_callback = callback
 
     def ws_change_call_back(self, callback):
+        """Set the callback function for workspace changes"""
         self.ads_observers.register_call_back(callback)
 
 
@@ -99,7 +100,8 @@ class ADSObserver(AnalysisDataServiceObserver):
         self.observeRename(True)
         self.callback = None
 
-    def clearHandle(self):
+    def clearHandle(self):  # pylint: disable=invalid-name
+        """Callback handle for ADS clear"""
         logger.debug("clearHandle")
         if self.callback:
             # NOTE: When closing the application, mantid will clear the ADS after
@@ -110,34 +112,37 @@ class ADSObserver(AnalysisDataServiceObserver):
             except RuntimeError:
                 pass
 
-    def addHandle(self, ws, _):
+    def addHandle(self, ws, _):  # pylint: disable=invalid-name
+        """Callback handle for ADS add"""
         logger.debug(f"addHandle: {ws}")
         if self.callback:
             self.callback("add", ws, filter_ws(ws))
 
-    def deleteHandle(self, ws, _):
+    def deleteHandle(self, ws, _):  # pylint: disable=invalid-name
+        """Callback handle for ADS delete"""
         logger.debug(f"deleteHandle: {ws}")
         if self.callback:
             self.callback("del", ws, None)
 
-    def replaceHandle(self, ws, _):
+    def replaceHandle(self, ws, _):  # pylint: disable=invalid-name
+        """Callback handle for ADS replace"""
         logger.debug(f"replaceHandle: {ws}")
         if self.callback:
             self.callback("del", ws, None)
             self.callback("add", ws, filter_ws(ws))
 
-    def renameHandle(self, old, new):
+    def renameHandle(self, old, new):  # pylint: disable=invalid-name
+        """Callback handle for ADS rename"""
         logger.debug(f"renameHandle: {old} {new}")
         if self.callback:
             self.callback("del", old, None)
             self.callback("add", new, filter_ws(new))
 
     def register_call_back(self, callback):
+        """Set the callback function for workspace changes"""
         self.callback = callback
 
 
 def filter_ws(name):
-    if mtd[name].isMDHistoWorkspace():
-        return "mde"
-    else:
-        return "norm"
+    """Return the type of workspace"""
+    return "mde" if mtd[name].isMDHistoWorkspace() else "norm"

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -159,7 +159,7 @@ def filter_ws(name):
             ws_type = "norm"
         else:
             logger.error(f"Workspace2D {name} has more than one bin per histogram")
-    elif ws_id == "MDEventWorkspace<MDEvent,4>":
+    elif ws_id.startswith("MDEventWorkspace") and mtd[name].getNumDims() >= 4:
         # More detailed check
         mde_ws = mtd[name]
         dim_0 = mde_ws.getDimension(0).name

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -151,10 +151,14 @@ def filter_ws(name):
     ws_id = mtd[name].id()
     ws_type = None
 
-    if "MDHistoWorkspace" in ws_id:
+    if ws_id == "MDHistoWorkspace":
         ws_type = "mdh"
-    elif "Workspace2D" in ws_id:
-        ws_type = "norm"
+    elif ws_id == "Workspace2D":
+        # verify if it is one bin per histogram
+        if mtd[name].blocksize() == 1:
+            ws_type = "norm"
+        else:
+            logger.error(f"Workspace2D {name} has more than one bin per histogram")
     elif ws_id == "MDEventWorkspace<MDEvent,4>":
         # More detailed check
         mde_ws = mtd[name]

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -106,7 +106,13 @@ class ADSObserver(AnalysisDataServiceObserver):
     def clearHandle(self):
         logger.debug("clearHandle")
         if self.callback:
-            self.callback("clear", None, None)
+            # NOTE: When closing the application, mantid will clear the ADS after
+            #       Shiver is closed, which will cause a RuntimeError as widgets
+            #       under shiver is no longer in scope.
+            try:
+                self.callback("clear", None, None)
+            except RuntimeError:
+                pass
 
     def addHandle(self, ws, _):
         logger.debug(f"addHandle: {ws}")

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -21,11 +21,6 @@ class HistogramModel:
         """Method to take filename and workspace type and load with correct algorithm"""
         ws_name, _ = os.path.splitext(os.path.basename(filename))
 
-        # Check if the workspace already exists
-        if mtd.doesExist(ws_name):
-            logger.warning(f"Workspace {ws_name} already exists")
-            return
-
         if ws_type == "mde":
             logger.information(f"Loading {filename} as MDE")
             load = AlgorithmManager.create("LoadMD")
@@ -52,7 +47,8 @@ class HistogramModel:
                 self.error_callback(str(err))
 
         if load.isExecuted():
-            self.ads_observers.addHandle(ws_name, None)
+            swn = load.getProperty("OutputWorkspace").value
+            self.ads_observers.addHandle(swn, None)
 
     def finish_loading(self, obs, filename, ws_type, error=False, msg=""):  # pylint: disable=too-many-arguments
         """This is the callback from the algorithm observer"""
@@ -123,7 +119,6 @@ class ADSObserver(AnalysisDataServiceObserver):
         logger.debug(f"deleteHandle: {ws}")
         if self.callback:
             self.callback("del", ws, None)
-        self.del_ws(ws)
 
     def replaceHandle(self, ws, _):
         logger.debug(f"replaceHandle: {ws}")

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -11,6 +11,8 @@ class HistogramPresenter:
         self.view.buttons.connect_load_file(self.load_file)
         self.model.connect_error_message(self.error_message)
 
+        self.model.ws_change_call_back(self.ws_changed)
+
     def load_file(self, file_type, filename):
         """Call model to load the filename from the UI file dialog"""
         self.model.load(filename, file_type)
@@ -28,3 +30,11 @@ class HistogramPresenter:
     def error_message(self, msg):
         """Pass error message to the view"""
         self.view.show_error_message(msg)
+
+    def ws_changed(self, action, name, ws_type):
+        if action == "add":
+            self.view.add_ws(name, ws_type)
+        elif action == "del":
+            self.view.del_ws(name)
+        elif action == "clear":
+            self.view.clear_ws()

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -32,6 +32,7 @@ class HistogramPresenter:
         self.view.show_error_message(msg)
 
     def ws_changed(self, action, name, ws_type):
+        """Pass the workspace change to the view"""
         if action == "add":
             self.view.add_ws(name, ws_type)
         elif action == "del":

--- a/src/shiver/shiver.py
+++ b/src/shiver/shiver.py
@@ -12,4 +12,5 @@ class Shiver(QMainWindow):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle("SHIVER")
-        self.setCentralWidget(MainWindow(self))
+        self.main_window = MainWindow(self)
+        self.setCentralWidget(self.main_window)

--- a/src/shiver/views/histogram.py
+++ b/src/shiver/views/histogram.py
@@ -93,12 +93,12 @@ class ADSList(QListWidget):
 
     def __init__(self, parent=None, WStype=None):
         super().__init__(parent)
-        self.WStype = WStype
+        self.ws_type = WStype
         self.setSortingEnabled(True)
 
     def add_ws(self, name, ws_type):
         """Adds a workspace to the list if it is of the correct type"""
-        if ws_type == self.WStype:
+        if ws_type == self.ws_type:
             self.addItem(name)
 
     def del_ws(self, name):

--- a/src/shiver/views/histogram.py
+++ b/src/shiver/views/histogram.py
@@ -44,6 +44,18 @@ class Histogram(QWidget):
         error.showMessage(msg)
         error.exec_()
 
+    def add_ws(self, name, ws_type):
+        """Adds a workspace to the list if it is of the correct type"""
+        self.input_workspaces.add_ws(name, ws_type)
+
+    def del_ws(self, name):
+        """Removes a workspace from the list if it is of the correct type"""
+        self.input_workspaces.del_ws(name)
+
+    def clear_ws(self):
+        """Clears all workspaces from the lists"""
+        self.input_workspaces.clear_ws()
+
 
 class InputWorkspaces(QGroupBox):
     """MDE and Normalization workspace widget"""
@@ -52,8 +64,8 @@ class InputWorkspaces(QGroupBox):
         super().__init__(parent)
         self.setTitle("Input data in memory")
 
-        self.mde_workspaces = ADSList(parent=self, WStype="MDH")
-        self.norm_workspaces = ADSList(parent=self, WStype="Norm")
+        self.mde_workspaces = ADSList(parent=self, WStype="mde")
+        self.norm_workspaces = ADSList(parent=self, WStype="norm")
 
         layout = QHBoxLayout()
         layout.addWidget(self.mde_workspaces)

--- a/src/shiver/views/histogram.py
+++ b/src/shiver/views/histogram.py
@@ -47,14 +47,17 @@ class Histogram(QWidget):
     def add_ws(self, name, ws_type):
         """Adds a workspace to the list if it is of the correct type"""
         self.input_workspaces.add_ws(name, ws_type)
+        self.histogram_workspaces.add_ws(name, ws_type)
 
     def del_ws(self, name):
         """Removes a workspace from the list if it is of the correct type"""
         self.input_workspaces.del_ws(name)
+        self.histogram_workspaces.del_ws(name)
 
     def clear_ws(self):
         """Clears all workspaces from the lists"""
         self.input_workspaces.clear_ws()
+        self.histogram_workspaces.clear_ws()
 
 
 class InputWorkspaces(QGroupBox):
@@ -98,7 +101,7 @@ class ADSList(QListWidget):
 
     def add_ws(self, name, ws_type):
         """Adds a workspace to the list if it is of the correct type"""
-        if ws_type == self.ws_type:
+        if ws_type == self.ws_type and name != "None":
             self.addItem(name)
 
     def del_ws(self, name):
@@ -210,7 +213,19 @@ class HistogramWorkspaces(QGroupBox):
         super().__init__(parent)
         self.setTitle("Histogram data in memory")
 
-        self.histogram_workspaces = QListWidget()
+        self.histogram_workspaces = ADSList(parent=self, WStype="mdh")
         layout = QVBoxLayout()
         layout.addWidget(self.histogram_workspaces)
         self.setLayout(layout)
+
+    def add_ws(self, name, ws_type):
+        """Adds a workspace to the list if it is of the correct type"""
+        self.histogram_workspaces.add_ws(name, ws_type)
+
+    def del_ws(self, name):
+        """Removes a workspace from the list if it is of the correct type"""
+        self.histogram_workspaces.del_ws(name)
+
+    def clear_ws(self):
+        """Clears all workspaces from the lists"""
+        self.histogram_workspaces.clear()

--- a/src/shiver/views/histogram.py
+++ b/src/shiver/views/histogram.py
@@ -15,6 +15,7 @@ from qtpy.QtWidgets import (
     QDoubleSpinBox,
     QErrorMessage,
 )
+from qtpy.QtCore import Qt
 
 from .loading_buttons import LoadingButtons
 
@@ -51,13 +52,47 @@ class InputWorkspaces(QGroupBox):
         super().__init__(parent)
         self.setTitle("Input data in memory")
 
-        self.mde_workspaces = QListWidget()
-        self.norm_workspaces = QListWidget()
+        self.mde_workspaces = ADSList(parent=self, WStype="MDH")
+        self.norm_workspaces = ADSList(parent=self, WStype="Norm")
 
         layout = QHBoxLayout()
         layout.addWidget(self.mde_workspaces)
         layout.addWidget(self.norm_workspaces)
         self.setLayout(layout)
+
+    def add_ws(self, name, ws_type):
+        """Adds a workspace to the list if it is of the correct type"""
+        self.mde_workspaces.add_ws(name, ws_type)
+        self.norm_workspaces.add_ws(name, ws_type)
+
+    def del_ws(self, name):
+        """Removes a workspace from the list if it is of the correct type"""
+        self.mde_workspaces.del_ws(name)
+        self.norm_workspaces.del_ws(name)
+
+    def clear_ws(self):
+        """Clears all workspaces from the lists"""
+        self.mde_workspaces.clear()
+        self.norm_workspaces.clear()
+
+
+class ADSList(QListWidget):
+    """List widget that will add and remove items from the ADS"""
+
+    def __init__(self, parent=None, WStype=None):
+        super().__init__(parent)
+        self.WStype = WStype
+        self.setSortingEnabled(True)
+
+    def add_ws(self, name, ws_type):
+        """Adds a workspace to the list if it is of the correct type"""
+        if ws_type == self.WStype:
+            self.addItem(name)
+
+    def del_ws(self, name):
+        """Removes a workspace from the list if it is of the correct type"""
+        for item in self.findItems(name, Qt.MatchExactly):
+            self.takeItem(self.indexFromItem(item).row())
 
 
 class HistogramParameter(QGroupBox):

--- a/src/shiver/views/mainwindow.py
+++ b/src/shiver/views/mainwindow.py
@@ -34,3 +34,7 @@ class MainWindow(QWidget):
         layout.addWidget(tabs)
         layout.addWidget(AlgorithmProgressWidget(self))
         self.setLayout(layout)
+
+        # register child widgets to make testing easier
+        self.histogram = histogram
+        self.generate = generate

--- a/tests/views/test_histogram.py
+++ b/tests/views/test_histogram.py
@@ -18,4 +18,5 @@ def test_histogram(qtbot):
     )
 
     # check that the workspace is in the norm list
-    assert shiver.main_window.histogram.input_workspaces.norm_workspaces.count() == 1
+    assert shiver.main_window.histogram.input_workspaces.mde_workspaces.count() == 1
+    assert shiver.main_window.histogram.input_workspaces.norm_workspaces.count() == 0

--- a/tests/views/test_histogram.py
+++ b/tests/views/test_histogram.py
@@ -1,7 +1,8 @@
 """UI test for the histogram tab"""
 import os
+from mantid.simpleapi import LoadMD  # pylint: disable=no-name-in-module
 from shiver import Shiver
-from mantid.simpleapi import LoadMD
+
 
 def test_histogram(qtbot):
     """Test the mde and norm lists"""

--- a/tests/views/test_histogram.py
+++ b/tests/views/test_histogram.py
@@ -4,7 +4,6 @@ from mantid.simpleapi import LoadMD  # pylint: disable=no-name-in-module
 from shiver import Shiver
 
 
-
 def test_histogram(qtbot):
     """Test the mde and norm lists"""
     shiver = Shiver()

--- a/tests/views/test_histogram.py
+++ b/tests/views/test_histogram.py
@@ -1,6 +1,10 @@
 """UI test for the histogram tab"""
 import os
-from mantid.simpleapi import LoadMD  # pylint: disable=no-name-in-module
+from mantid.simpleapi import (  # pylint: disable=no-name-in-module
+    LoadMD,
+    MakeSlice,
+    CreateSampleWorkspace,
+)
 from shiver import Shiver
 
 
@@ -10,13 +14,48 @@ def test_histogram(qtbot):
     qtbot.addWidget(shiver)
     shiver.show()
 
+    # mde workspace
     LoadMD(
         Filename=os.path.join(
             os.path.dirname(os.path.abspath(__file__)), "../data/mde/merged_mde_MnO_25meV_5K_unpol_178921-178926.nxs"
         ),
         OutputWorkspace="data",
     )
+    # check
+    med_list = shiver.main_window.histogram.input_workspaces.mde_workspaces
+    assert med_list.count() == 1
+    assert med_list.item(0).text() == "data"
 
-    # check that the workspace is in the norm list
-    assert shiver.main_window.histogram.input_workspaces.mde_workspaces.count() == 1
-    assert shiver.main_window.histogram.input_workspaces.norm_workspaces.count() == 0
+    # norm workspace
+    CreateSampleWorkspace(OutputWorkspace="ws2d", BinWidth=20000)
+    # check
+    norm_list = shiver.main_window.histogram.input_workspaces.norm_workspaces
+    assert norm_list.count() == 1
+    assert norm_list.item(0).text() == "ws2d"
+
+    # mdh workspace
+    MakeSlice(
+        InputWorkspace="data",
+        BackgroundWorkspace=None,
+        NormalizationWorkspace=None,
+        QDimension0="0,0,1",
+        QDimension1="1,1,0",
+        QDimension2="-1,1,0",
+        Dimension0Name="QDimension1",
+        Dimension0Binning="0.35,0.025,0.65",
+        Dimension1Name="QDimension0",
+        Dimension1Binning="0.45,0.55",
+        Dimension2Name="QDimension2",
+        Dimension2Binning="-0.2,0.2",
+        Dimension3Name="DeltaE",
+        Dimension3Binning="-0.5,0.5",
+        SymmetryOperations=None,
+        ConvertToChi=False,
+        Temperature=None,
+        Smoothing=1,
+        OutputWorkspace="line",
+    )
+    # check that the workspace
+    histogram_list = shiver.main_window.histogram.histogram_workspaces.histogram_workspaces
+    assert histogram_list.count() == 1
+    assert histogram_list.item(0).text() == "line"

--- a/tests/views/test_histogram.py
+++ b/tests/views/test_histogram.py
@@ -1,0 +1,20 @@
+"""UI test for the histogram tab"""
+import os
+from shiver import Shiver
+from mantid.simpleapi import LoadMD
+
+def test_histogram(qtbot):
+    """Test the mde and norm lists"""
+    shiver = Shiver()
+    qtbot.addWidget(shiver)
+    shiver.show()
+
+    LoadMD(
+        Filename=os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "../data/mde/merged_mde_MnO_25meV_5K_unpol_178921-178926.nxs"
+        ),
+        OutputWorkspace="data",
+    )
+
+    # check that the workspace is in the norm list
+    assert shiver.main_window.histogram.input_workspaces.norm_workspaces.count() == 1


### PR DESCRIPTION
This PR added the viewer (QListWidget) for MDE and normalization workspaces.

Test instructions
============

- setup dev env and clone the feature branch (perform editable install if necessary)
- start shiver
- load the test data set by clicking `Load_MDE`
![image](https://user-images.githubusercontent.com/5064852/225730625-c67f1492-6355-478c-b81b-a5c3ec6eaaf7.png)
- the workspace name should appear in the first column (given test mde data evaluate to false when checking `isMDHistoWorkspace()`)
![image](https://user-images.githubusercontent.com/5064852/225914507-69492f63-de1b-4aa7-8f5a-29ca9638ed78.png)



> IBM item: [Story587](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=587)