### PR TITLE
Rearrange input workspace tables

### DIFF
--- a/src/shiver/views/histogram.py
+++ b/src/shiver/views/histogram.py
@@ -70,9 +70,11 @@ class InputWorkspaces(QGroupBox):
         self.mde_workspaces = ADSList(parent=self, WStype="mde")
         self.norm_workspaces = ADSList(parent=self, WStype="norm")
 
-        layout = QHBoxLayout()
-        layout.addWidget(self.mde_workspaces)
-        layout.addWidget(self.norm_workspaces)
+        layout = QVBoxLayout()
+        layout.addWidget(QLabel("MDE name"))
+        layout.addWidget(self.mde_workspaces, stretch=2)
+        layout.addWidget(QLabel("Normalization"))
+        layout.addWidget(self.norm_workspaces, stretch=1)
         self.setLayout(layout)
 
     def add_ws(self, name, ws_type):


### PR DESCRIPTION
They should now look like this
![2023-03-20-160917_240x576_scrot](https://user-images.githubusercontent.com/5595210/226454193-2e535248-1ab0-4803-871e-b5a93567b4ee.png)
