### PR TITLE
Update context menu connection, allow it to be testable, and add tests

### DIFF
--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -77,40 +77,46 @@ class MDEList(ADSList):
         self._background = None
         self.rename_workspace_callback = None
         self.delete_workspace_callback = None
+        self.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.customContextMenuRequested.connect(self.contextMenu)
 
-    def contextMenuEvent(self, event):  # pylint: disable=invalid-name
-        """override right-click event handler"""
-        if self.currentItem():
-            selected_ws = self.currentItem().text()
+    def contextMenu(self, pos):  # pylint: disable=invalid-name
+        """right-click event handler"""
+        selected_ws = self.itemAt(pos)
+        if selected_ws is None:
+            return
 
-            menu = QMenu(self)
+        selected_ws = selected_ws.text()
 
-            if selected_ws != self._data:
-                set_data = QAction("Set as data")
-                set_data.triggered.connect(partial(self.set_data, selected_ws))
-                menu.addAction(set_data)
+        menu = QMenu(self)
 
-            if selected_ws == self._background:
-                background = QAction("Unset as background")
-                background.triggered.connect(partial(self.unset_background, selected_ws))
-            else:
-                background = QAction("Set as background")
-                background.triggered.connect(partial(self.set_background, selected_ws))
+        if selected_ws != self._data:
+            set_data = QAction("Set as data")
+            set_data.triggered.connect(partial(self.set_data, selected_ws))
+            menu.addAction(set_data)
 
-            menu.addAction(background)
-            menu.addSeparator()
+        if selected_ws == self._background:
+            background = QAction("Unset as background")
+            background.triggered.connect(partial(self.unset_background, selected_ws))
+        else:
+            background = QAction("Set as background")
+            background.triggered.connect(partial(self.set_background, selected_ws))
 
-            rename = QAction("Rename")
-            rename.triggered.connect(partial(self.rename_ws, selected_ws))
+        menu.addAction(background)
+        menu.addSeparator()
 
-            menu.addAction(rename)
+        rename = QAction("Rename")
+        rename.triggered.connect(partial(self.rename_ws, selected_ws))
 
-            delete = QAction("Delete")
-            delete.triggered.connect(partial(self.delete_ws, selected_ws))
+        menu.addAction(rename)
 
-            menu.addAction(delete)
+        delete = QAction("Delete")
+        delete.triggered.connect(partial(self.delete_ws, selected_ws))
 
-            menu.exec_(event.globalPos())
+        menu.addAction(delete)
+
+        menu.exec_(self.mapToGlobal(pos))
+        menu.setParent(None)  # Allow this QMenu instance to be cleaned up
 
     def set_data(self, name):
         """method to set the selected workspace as 'data'"""

--- a/tests/views/test_mde_workspaces.py
+++ b/tests/views/test_mde_workspaces.py
@@ -1,0 +1,171 @@
+"""UI tests for the MDE list tables"""
+from functools import partial
+from qtpy.QtWidgets import QApplication, QMenu, QInputDialog, QLineEdit
+from qtpy.QtCore import Qt, QTimer
+from qtpy.QtGui import QContextMenuEvent
+from shiver.views.workspace_tables import MDEList
+
+
+def test_mde_workspaces_menu(qtbot):
+    """Test the mde and norm lists"""
+    mde_table = MDEList(WStype="mde")
+    qtbot.addWidget(mde_table)
+    mde_table.show()
+
+    mde_table.add_ws("mde1", "mde")
+    mde_table.add_ws("mde2", "mde")
+    mde_table.add_ws("mde3", "mde")
+
+    assert mde_table.count() == 3
+    assert mde_table.data is None
+    assert mde_table.background is None
+
+    qtbot.wait(100)
+
+    # This is to handle the menu
+    def handle_menu(action_number):
+        menu = mde_table.findChild(QMenu)
+
+        for _ in range(action_number):
+            qtbot.keyClick(menu, Qt.Key_Down)
+        qtbot.keyClick(menu, Qt.Key_Enter)
+
+    # right-click first item and select "Set as data"
+    item = mde_table.item(0)
+    assert item.text() == "mde1"
+
+    QTimer.singleShot(100, partial(handle_menu, 1))
+
+    QApplication.postEvent(
+        mde_table.viewport(), QContextMenuEvent(QContextMenuEvent.Mouse, mde_table.visualItemRect(item).center())
+    )
+
+    qtbot.wait(100)
+    assert mde_table.count() == 3
+    assert mde_table.data == "mde1"
+    assert mde_table.background is None
+
+    # right-click second item and select "Set as data"
+    item = mde_table.item(1)
+    assert item.text() == "mde2"
+
+    QTimer.singleShot(100, partial(handle_menu, 1))
+
+    QApplication.postEvent(
+        mde_table.viewport(), QContextMenuEvent(QContextMenuEvent.Mouse, mde_table.visualItemRect(item).center())
+    )
+
+    qtbot.wait(100)
+    assert mde_table.count() == 3
+    assert mde_table.data == "mde2"
+    assert mde_table.background is None
+
+    # right-click third item and select "Set as background"
+    item = mde_table.item(2)
+    assert item.text() == "mde3"
+
+    QTimer.singleShot(100, partial(handle_menu, 2))
+
+    QApplication.postEvent(
+        mde_table.viewport(), QContextMenuEvent(QContextMenuEvent.Mouse, mde_table.visualItemRect(item).center())
+    )
+
+    qtbot.wait(100)
+    assert mde_table.count() == 3
+    assert mde_table.data == "mde2"
+    assert mde_table.background == "mde3"
+
+    # right-click third item and select "Set as data"
+    item = mde_table.item(2)
+    assert item.text() == "mde3"
+
+    QTimer.singleShot(100, partial(handle_menu, 1))
+
+    QApplication.postEvent(
+        mde_table.viewport(), QContextMenuEvent(QContextMenuEvent.Mouse, mde_table.visualItemRect(item).center())
+    )
+
+    qtbot.wait(100)
+    assert mde_table.count() == 3
+    assert mde_table.data == "mde3"
+    assert mde_table.background is None
+
+    # right-click third item and select "Set as background"
+    item = mde_table.item(2)
+    assert item.text() == "mde3"
+
+    QTimer.singleShot(100, partial(handle_menu, 1))
+
+    QApplication.postEvent(
+        mde_table.viewport(), QContextMenuEvent(QContextMenuEvent.Mouse, mde_table.visualItemRect(item).center())
+    )
+
+    qtbot.wait(100)
+    assert mde_table.count() == 3
+    assert mde_table.data is None
+    assert mde_table.background == "mde3"
+
+    # right-click third item and select "Unset as background"
+    item = mde_table.item(2)
+    assert item.text() == "mde3"
+
+    QTimer.singleShot(100, partial(handle_menu, 2))
+
+    QApplication.postEvent(
+        mde_table.viewport(), QContextMenuEvent(QContextMenuEvent.Mouse, mde_table.visualItemRect(item).center())
+    )
+
+    qtbot.wait(100)
+    assert mde_table.count() == 3
+    assert mde_table.data is None
+    assert mde_table.background is None
+
+    # right-click first item and select "Delete"
+    deleted = []
+
+    def delete_callback(name):
+        deleted.append(name)
+
+    mde_table.delete_workspace_callback = delete_callback
+
+    item = mde_table.item(0)
+    assert item.text() == "mde1"
+
+    QTimer.singleShot(100, partial(handle_menu, 4))
+
+    QApplication.postEvent(
+        mde_table.viewport(), QContextMenuEvent(QContextMenuEvent.Mouse, mde_table.visualItemRect(item).center())
+    )
+
+    qtbot.wait(100)
+    assert len(deleted) == 1
+    assert deleted[0] == "mde1"
+
+    # right-click first item and select "Rename"
+    rename = []
+
+    def rename_callback(old, new):
+        rename.append((old, new))
+
+    mde_table.rename_workspace_callback = rename_callback
+
+    def handle_dialog():
+        dialog = mde_table.findChild(QInputDialog)
+        line_edit = dialog.findChild(QLineEdit)
+        qtbot.keyClicks(line_edit, "new_ws_name")
+        qtbot.wait(100)
+        qtbot.keyClick(line_edit, Qt.Key_Enter)
+
+    item = mde_table.item(0)
+    assert item.text() == "mde1"
+
+    QTimer.singleShot(100, partial(handle_menu, 3))
+    QTimer.singleShot(200, handle_dialog)
+
+    QApplication.postEvent(
+        mde_table.viewport(), QContextMenuEvent(QContextMenuEvent.Mouse, mde_table.visualItemRect(item).center())
+    )
+
+    qtbot.wait(500)
+    assert len(rename) == 1
+    assert rename[0] == ("mde1", "new_ws_name")


### PR DESCRIPTION
Adding tests to the MDE workspace menu for "Set as Data", "Set as Background", "Rename" and "Delete".

[933](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=933)