### PR TITLE
Add correction table

### DIFF
--- a/src/shiver/models/corrections.py
+++ b/src/shiver/models/corrections.py
@@ -78,7 +78,7 @@ class CorrectionsModel:
         output_ws_name: str,
     ) -> None:
         """Apply detailed balance to the workspace.
-        
+
         Parameters
         ----------
         ws_name : str
@@ -164,7 +164,7 @@ class CorrectionsModel:
 
     def connect_error_message(self, callback):
         """Set the callback function for error messages.
-        
+
         Parameters
         ----------
         callback : function

--- a/src/shiver/models/corrections.py
+++ b/src/shiver/models/corrections.py
@@ -1,9 +1,12 @@
 """Model for Corrections tab"""
 # pylint: disable=no-name-in-module
-from mantid.api import AlgorithmManager, AlgorithmObserver
+import time
+from typing import Tuple
+from mantid.api import mtd, AlgorithmManager, AlgorithmObserver
 from mantid.kernel import Logger
 
 logger = Logger("SHIVER")
+
 
 class CorrectionsModel:
     """Corrections table model"""
@@ -12,12 +15,40 @@ class CorrectionsModel:
         self.algorithms_observers = set()  # need to add them here so they stay in scope
         self.error_callback = None
 
+    def apply(
+        self,
+        ws_name: str,
+        detailed_balance: bool,
+        hyspec_polarizer_transmission: bool,
+        temperature: str = "",
+    ) -> None:
+        """Apply corrections"""
+        output_ws_name = f"{ws_name}_correction"
+        if detailed_balance:
+            self.apply_detailed_balance(
+                ws_name,
+                temperature,
+                output_ws_name,
+            )
+        #
+        if hyspec_polarizer_transmission:
+            input_ws_name = ws_name
+            if detailed_balance:
+                # wait for detailed balance to finish
+                while not mtd.doesExist(output_ws_name):
+                    time.sleep(0.1)
+                input_ws_name = output_ws_name
+            self.apply_scattered_transmission_correction(
+                input_ws_name,
+                output_ws_name,
+            )
+
     def apply_detailed_balance(
-            self,
-            ws_name: str,
-            temperature: str,
-            output_ws_name:str,
-        ) -> None:
+        self,
+        ws_name: str,
+        temperature: str,
+        output_ws_name: str,
+    ) -> None:
         """Apply detailed balance to the workspace"""
         alg_obs = ApplyDetailedBalanceMDObserver(
             parent=self,
@@ -43,9 +74,9 @@ class CorrectionsModel:
                 self.error_callback(str(err))
 
     def apply_scattered_transmission_correction(
-            self,
-            ws_name: str,
-            output_ws_name: str,
+        self,
+        ws_name: str,
+        output_ws_name: str,
     ) -> None:
         """Apply DGSScatterTransmissionCorrection to the workspace"""
         alg_obs = DgsScatteredTransmissionCorrectionMDObserver(
@@ -74,12 +105,16 @@ class CorrectionsModel:
             if self.error_callback:
                 self.error_callback(str(err))
 
+    def connect_error_message(self, callback):
+        """Set the callback function for error messages"""
+        self.error_callback = callback
+
     def apply_detailed_balance_finished(
-            self,
-            ws_name: str,
-            alg: "ApplyDetailedBalanceMDObserver",
-            error: bool=False,
-            msg="",
+        self,
+        ws_name: str,
+        alg: "ApplyDetailedBalanceMDObserver",
+        error: bool = False,
+        msg="",
     ) -> None:
         """Call when ApplyDetailedBalanceMD finishes"""
         if error:
@@ -91,11 +126,11 @@ class CorrectionsModel:
         self.algorithms_observers.remove(alg)
 
     def apply_scattered_transmission_correction_finished(
-            self,
-            ws_name: str,
-            alg: "DgsScatteredTransmissionCorrectionMDObserver",
-            error: bool=False,
-            msg="",
+        self,
+        ws_name: str,
+        alg: "DgsScatteredTransmissionCorrectionMDObserver",
+        error: bool = False,
+        msg="",
     ) -> None:
         """Call when DgsScatteredTransmissionCorrectionMD finishes"""
         if error:
@@ -105,6 +140,28 @@ class CorrectionsModel:
         else:
             logger.information(f"Finished DgsScatteredTransmissionCorrectionMD for {ws_name}")
         self.algorithms_observers.remove(alg)
+
+    def get_ws_alg_histories(self, ws_name: str) -> list:
+        """Get algorithm histories of the workspace"""
+        if mtd.doesExist(ws_name):
+            return mtd[ws_name].getHistory().getAlgorithmHistories()
+        return []
+
+    def has_apply_detailed_balance(self, ws_name: str) -> Tuple[bool, str]:
+        """Check if the workspace has ApplyDetailedBalanceMD applied"""
+        alg_histories = self.get_ws_alg_histories(ws_name)
+        for alg_history in alg_histories:
+            if alg_history.name() == "ApplyDetailedBalanceMD":
+                return True, alg_history.getPropertyValue("Temperature")
+        return False, ""
+
+    def has_scattered_transmission_correction(self, ws_name: str) -> bool:
+        """Check if the workspace has DgsScatteredTransmissionCorrectionMD applied"""
+        alg_histories = self.get_ws_alg_histories(ws_name)
+        for alg_history in alg_histories:
+            if alg_history.name() == "DgsScatteredTransmissionCorrectionMD":
+                return True
+        return False
 
 
 class ApplyDetailedBalanceMDObserver(AlgorithmObserver):
@@ -134,8 +191,12 @@ class DgsScatteredTransmissionCorrectionMDObserver(AlgorithmObserver):
 
     def finishHandle(self):  # pylint: disable=invalid-name
         """Call upon algorithm finishing"""
-        self.parent.apply_scattered_transmission_correction_finished(ws_name=self.ws_name, alg=self, error=False, msg="")
+        self.parent.apply_scattered_transmission_correction_finished(
+            ws_name=self.ws_name, alg=self, error=False, msg=""
+        )
 
     def errorHandle(self, msg):  # pylint: disable=invalid-name
         """Call upon algorithm error"""
-        self.parent.apply_scattered_transmission_correction_finished(ws_name=self.ws_name, alg=self, error=True, msg=msg)
+        self.parent.apply_scattered_transmission_correction_finished(
+            ws_name=self.ws_name, alg=self, error=True, msg=msg
+        )

--- a/src/shiver/models/corrections.py
+++ b/src/shiver/models/corrections.py
@@ -110,7 +110,7 @@ class CorrectionsModel:
             alg.setProperty("Temperature", temperature)
             alg.setProperty("OutputWorkspace", output_ws_name)
             alg.executeAsync()
-        except ValueError as err:
+        except RuntimeError as err:
             logger.error(str(err))
             if self.error_callback:
                 self.error_callback(str(err))
@@ -157,7 +157,7 @@ class CorrectionsModel:
             alg.setProperty("ExponentFactor", exponent_factor)
             alg.setProperty("OutputWorkspace", output_ws_name)
             alg.executeAsync()
-        except ValueError as err:
+        except RuntimeError as err:
             logger.error(str(err))
             if self.error_callback:
                 self.error_callback(str(err))

--- a/src/shiver/models/corrections.py
+++ b/src/shiver/models/corrections.py
@@ -22,8 +22,36 @@ class CorrectionsModel:
         hyspec_polarizer_transmission: bool,
         temperature: str = "",
     ) -> None:
-        """Apply corrections"""
-        output_ws_name = f"{ws_name}_correction"
+        """Apply corrections.
+
+        Parameters
+        ----------
+        ws_name : str
+            Workspace name
+        detailed_balance : bool
+            Apply detailed balance
+        hyspec_polarizer_transmission : bool
+            Apply HYSPEC polarizer transmission correction
+        temperature : str, optional
+            Temperature value as string or log entry contains temperature, by default ""
+
+        Return
+        ------
+        None
+
+        Note
+        ----
+        The applied correction is noted as the suffix of the workspace name
+          - detailed balance: "_DB"
+          - HYSPEC polarizer transmission: "_PT"
+        """
+        # decide the final output workspace name
+        output_ws_name = ws_name
+        if detailed_balance:
+            output_ws_name = f"{ws_name}_DB"
+        if hyspec_polarizer_transmission:
+            output_ws_name = f"{output_ws_name}_PT"
+
         if detailed_balance:
             self.apply_detailed_balance(
                 ws_name,
@@ -49,7 +77,21 @@ class CorrectionsModel:
         temperature: str,
         output_ws_name: str,
     ) -> None:
-        """Apply detailed balance to the workspace"""
+        """Apply detailed balance to the workspace.
+        
+        Parameters
+        ----------
+        ws_name : str
+            Workspace name
+        temperature : str
+            Temperature value as string or log entry contains temperature
+        output_ws_name : str
+            Output workspace name
+
+        Returns
+        -------
+        None
+        """
         alg_obs = ApplyDetailedBalanceMDObserver(
             parent=self,
             ws_name=ws_name,
@@ -78,14 +120,29 @@ class CorrectionsModel:
         ws_name: str,
         output_ws_name: str,
     ) -> None:
-        """Apply DGSScatterTransmissionCorrection to the workspace"""
+        """Apply DGSScatterTransmissionCorrection to the workspace.
+
+        ref: IOP Conf. Series: Journal of Physics: Conf. Series 862 (2017) 012023
+             `Figure 3 Right <https://doi:10.1088/1742-6596/862/1/012023>`_
+
+        Parameters
+        ----------
+        ws_name : str
+            Workspace name
+        output_ws_name : str
+            Output workspace name
+
+        Returns
+        -------
+        None
+        """
         alg_obs = DgsScatteredTransmissionCorrectionMDObserver(
             parent=self,
             ws_name=ws_name,
         )
         self.algorithms_observers.add(alg_obs)
 
-        exponent_factor = 1.0 / 11.0  # fixed value
+        exponent_factor = 1.0 / 11.0  # see ref above
 
         logger.information(f"Applying DGS Scattered Transmission Correction with exponent factor {exponent_factor}")
         alg = AlgorithmManager.create("DgsScatteredTransmissionCorrectionMD")
@@ -106,7 +163,17 @@ class CorrectionsModel:
                 self.error_callback(str(err))
 
     def connect_error_message(self, callback):
-        """Set the callback function for error messages"""
+        """Set the callback function for error messages.
+        
+        Parameters
+        ----------
+        callback : function
+            Callback function
+
+        Returns
+        -------
+        None
+        """
         self.error_callback = callback
 
     def apply_detailed_balance_finished(
@@ -116,7 +183,23 @@ class CorrectionsModel:
         error: bool = False,
         msg="",
     ) -> None:
-        """Call when ApplyDetailedBalanceMD finishes"""
+        """Call when ApplyDetailedBalanceMD finishes.
+
+        Parameters
+        ----------
+        ws_name : str
+            Workspace name
+        alg : ApplyDetailedBalanceMDObserver
+            Observer
+        error : bool, optional
+            Error flag, by default False
+        msg : str, optional
+            Error message, by default ""
+
+        Returns
+        -------
+        None
+        """
         if error:
             logger.error(f"Error in ApplyDetailedBalanceMD for {ws_name}")
             if self.error_callback:
@@ -132,7 +215,23 @@ class CorrectionsModel:
         error: bool = False,
         msg="",
     ) -> None:
-        """Call when DgsScatteredTransmissionCorrectionMD finishes"""
+        """Call when DgsScatteredTransmissionCorrectionMD finishes.
+
+        Parameters
+        ----------
+        ws_name : str
+            Workspace name
+        alg : DgsScatteredTransmissionCorrectionMDObserver
+            Observer
+        error : bool, optional
+            Error flag, by default False
+        msg : str, optional
+            Error message, by default ""
+
+        Returns
+        -------
+        None
+        """
         if error:
             logger.error(f"Error in DgsScatteredTransmissionCorrectionMD for {ws_name}")
             if self.error_callback:
@@ -142,13 +241,36 @@ class CorrectionsModel:
         self.algorithms_observers.remove(alg)
 
     def get_ws_alg_histories(self, ws_name: str) -> list:
-        """Get algorithm histories of the workspace"""
+        """Get algorithm histories of the workspace.
+
+        Parameters
+        ----------
+        ws_name : str
+            Workspace name
+
+        Returns
+        -------
+        list
+            List of algorithm histories
+        """
         if mtd.doesExist(ws_name):
             return mtd[ws_name].getHistory().getAlgorithmHistories()
         return []
 
     def has_apply_detailed_balance(self, ws_name: str) -> Tuple[bool, str]:
-        """Check if the workspace has ApplyDetailedBalanceMD applied"""
+        """Check if the workspace has ApplyDetailedBalanceMD applied.
+
+        Parameters
+        ----------
+        ws_name : str
+            Workspace name
+
+        Returns
+        -------
+        Tuple[bool, str]
+            True if the workspace has ApplyDetailedBalanceMD applied
+            Temperature if the workspace has ApplyDetailedBalanceMD applied
+        """
         alg_histories = self.get_ws_alg_histories(ws_name)
         for alg_history in alg_histories:
             if alg_history.name() == "ApplyDetailedBalanceMD":
@@ -156,7 +278,18 @@ class CorrectionsModel:
         return False, ""
 
     def has_scattered_transmission_correction(self, ws_name: str) -> bool:
-        """Check if the workspace has DgsScatteredTransmissionCorrectionMD applied"""
+        """Check if the workspace has DgsScatteredTransmissionCorrectionMD applied.
+
+        Parameters
+        ----------
+        ws_name : str
+            Workspace name
+
+        Returns
+        -------
+        bool
+            True if the workspace has DgsScatteredTransmissionCorrectionMD applied.
+        """
         alg_histories = self.get_ws_alg_histories(ws_name)
         for alg_history in alg_histories:
             if alg_history.name() == "DgsScatteredTransmissionCorrectionMD":

--- a/src/shiver/models/corrections.py
+++ b/src/shiver/models/corrections.py
@@ -1,0 +1,141 @@
+"""Model for Corrections tab"""
+# pylint: disable=no-name-in-module
+from mantid.api import AlgorithmManager, AlgorithmObserver
+from mantid.kernel import Logger
+
+logger = Logger("SHIVER")
+
+class CorrectionsModel:
+    """Corrections table model"""
+
+    def __init__(self) -> None:
+        self.algorithms_observers = set()  # need to add them here so they stay in scope
+        self.error_callback = None
+
+    def apply_detailed_balance(
+            self,
+            ws_name: str,
+            temperature: str,
+            output_ws_name:str,
+        ) -> None:
+        """Apply detailed balance to the workspace"""
+        alg_obs = ApplyDetailedBalanceMDObserver(
+            parent=self,
+            ws_name=ws_name,
+        )
+        self.algorithms_observers.add(alg_obs)
+
+        alg = AlgorithmManager.create("ApplyDetailedBalanceMD")
+
+        alg_obs.observeFinish(alg)
+        alg_obs.observeError(alg)
+
+        alg.initialize()
+        alg.setLogging(False)
+        try:
+            alg.setProperty("InputWorkspace", ws_name)
+            alg.setProperty("Temperature", temperature)
+            alg.setProperty("OutputWorkspace", output_ws_name)
+            alg.executeAsync()
+        except ValueError as err:
+            logger.error(str(err))
+            if self.error_callback:
+                self.error_callback(str(err))
+
+    def apply_scattered_transmission_correction(
+            self,
+            ws_name: str,
+            output_ws_name: str,
+    ) -> None:
+        """Apply DGSScatterTransmissionCorrection to the workspace"""
+        alg_obs = DgsScatteredTransmissionCorrectionMDObserver(
+            parent=self,
+            ws_name=ws_name,
+        )
+        self.algorithms_observers.add(alg_obs)
+
+        exponent_factor = 1.0 / 11.0  # fixed value
+
+        logger.information(f"Applying DGS Scattered Transmission Correction with exponent factor {exponent_factor}")
+        alg = AlgorithmManager.create("DgsScatteredTransmissionCorrectionMD")
+
+        alg_obs.observeFinish(alg)
+        alg_obs.observeError(alg)
+
+        alg.initialize()
+        alg.setLogging(False)
+        try:
+            alg.setProperty("InputWorkspace", ws_name)
+            alg.setProperty("ExponentFactor", exponent_factor)
+            alg.setProperty("OutputWorkspace", output_ws_name)
+            alg.executeAsync()
+        except ValueError as err:
+            logger.error(str(err))
+            if self.error_callback:
+                self.error_callback(str(err))
+
+    def apply_detailed_balance_finished(
+            self,
+            ws_name: str,
+            alg: "ApplyDetailedBalanceMDObserver",
+            error: bool=False,
+            msg="",
+    ) -> None:
+        """Call when ApplyDetailedBalanceMD finishes"""
+        if error:
+            logger.error(f"Error in ApplyDetailedBalanceMD for {ws_name}")
+            if self.error_callback:
+                self.error_callback(msg)
+        else:
+            logger.information(f"Finished ApplyDetailedBalanceMD for {ws_name}")
+        self.algorithms_observers.remove(alg)
+
+    def apply_scattered_transmission_correction_finished(
+            self,
+            ws_name: str,
+            alg: "DgsScatteredTransmissionCorrectionMDObserver",
+            error: bool=False,
+            msg="",
+    ) -> None:
+        """Call when DgsScatteredTransmissionCorrectionMD finishes"""
+        if error:
+            logger.error(f"Error in DgsScatteredTransmissionCorrectionMD for {ws_name}")
+            if self.error_callback:
+                self.error_callback(msg)
+        else:
+            logger.information(f"Finished DgsScatteredTransmissionCorrectionMD for {ws_name}")
+        self.algorithms_observers.remove(alg)
+
+
+class ApplyDetailedBalanceMDObserver(AlgorithmObserver):
+    """Observer for ApplyDetailedBalanceMD algorithm"""
+
+    def __init__(self, parent, ws_name: str) -> None:
+        super().__init__()
+        self.parent = parent
+        self.ws_name = ws_name
+
+    def finishHandle(self):  # pylint: disable=invalid-name
+        """Call upon algorithm finishing"""
+        self.parent.apply_detailed_balance_finished(ws_name=self.ws_name, alg=self, error=False, msg="")
+
+    def errorHandle(self, msg):  # pylint: disable=invalid-name
+        """Call upon algorithm error"""
+        self.parent.apply_detailed_balance_finished(ws_name=self.ws_name, alg=self, error=True, msg=msg)
+
+
+class DgsScatteredTransmissionCorrectionMDObserver(AlgorithmObserver):
+    """Observer for DgsScatteredTransmissionCorrectionMD algorithm"""
+
+    def __init__(self, parent, ws_name: str) -> None:
+        super().__init__()
+        self.parent = parent
+        self.ws_name = ws_name
+
+    def finishHandle(self):  # pylint: disable=invalid-name
+        """Call upon algorithm finishing"""
+        self.parent.apply_scattered_transmission_correction_finished(ws_name=self.ws_name, alg=self, error=False, msg="")
+
+    def errorHandle(self, msg):  # pylint: disable=invalid-name
+        """Call upon algorithm error"""
+        self.parent.apply_scattered_transmission_correction_finished(ws_name=self.ws_name, alg=self, error=True, msg=msg)

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -82,7 +82,7 @@ class HistogramModel:
         self.error_callback = callback
 
     def symmetry_operations(self, symmetry):
-        """Validate the symmetry value with mandit"""
+        """Validate the symmetry value with mantid"""
         if len(symmetry) != 0:
             if (
                 (symmetry.isnumeric() and SpaceGroupFactory.isSubscribedNumber(int(symmetry)))

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -89,10 +89,6 @@ class HistogramPresenter:
                 corrections_tab_view.hyspec_polarizer_transmission.setEnabled(False)
 
             # inline functions
-            def _show_error(msg):
-                """Show an error message"""
-                corrections_tab_view.show_error_message(msg)
-
             def _help():
                 """Show the help for the corrections tab"""
                 webbrowser.open("https://neutrons.github.io/Shiver/")
@@ -123,7 +119,7 @@ class HistogramPresenter:
                 corrections_tab_view.deleteLater()
 
             # connect inline functions to view
-            corrections_tab_model.connect_error_message(_show_error)
+            corrections_tab_model.connect_error_message(self.error_message)
             corrections_tab_view.help_button.clicked.connect(_help)
             corrections_tab_view.apply_button.clicked.connect(_apply)
             corrections_tab_view.cancel_button.clicked.connect(_cancel)

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -77,6 +77,17 @@ class HistogramPresenter:
             # create a new model
             corrections_tab_model = CorrectionsModel()
 
+            # populate initial values
+            has_detailed_balance, temperature = corrections_tab_model.has_apply_detailed_balance(name)
+            has_scattered_transmission_correction = corrections_tab_model.has_scattered_transmission_correction(name)
+            if has_detailed_balance:
+                corrections_tab_view.detailed_balance.setChecked(True)
+                corrections_tab_view.temperature.setText(str(temperature))
+                corrections_tab_view.detailed_balance.setEnabled(False)
+            if has_scattered_transmission_correction:
+                corrections_tab_view.hyspec_polarizer_transmission.setChecked(True)
+                corrections_tab_view.hyspec_polarizer_transmission.setEnabled(False)
+
             # inline functions
             def _show_error(msg):
                 """Show an error message"""
@@ -88,10 +99,18 @@ class HistogramPresenter:
 
             def _apply():
                 """Apply the corrections"""
+                do_detail_balance = (
+                    corrections_tab_view.detailed_balance.isChecked()
+                    and corrections_tab_view.detailed_balance.isEnabled()
+                )
+                do_polarizer_transmission = (
+                    corrections_tab_view.hyspec_polarizer_transmission.isChecked()
+                    and corrections_tab_view.hyspec_polarizer_transmission.isEnabled()
+                )
                 corrections_tab_model.apply(
                     name,
-                    corrections_tab_view.detailed_balance.isChecked(),
-                    corrections_tab_view.hyspec_polarizer_transmission.isChecked(),
+                    do_detail_balance,
+                    do_polarizer_transmission,
                     corrections_tab_view.temperature.text(),
                 )
                 # clean up
@@ -103,14 +122,6 @@ class HistogramPresenter:
                 tab_widget.setCurrentWidget(self._view)
                 corrections_tab_view.deleteLater()
 
-            # populate initial values
-            has_detailed_balance, temperature = corrections_tab_model.has_apply_detailed_balance(name)
-            has_scattered_transmission_correction = corrections_tab_model.has_scattered_transmission_correction(name)
-            if has_detailed_balance:
-                corrections_tab_view.detailed_balance.setChecked(True)
-                corrections_tab_view.temperature.setText(str(temperature))
-            if has_scattered_transmission_correction:
-                corrections_tab_view.hyspec_polarizer_transmission.setChecked(True)
             # connect inline functions to view
             corrections_tab_model.connect_error_message(_show_error)
             corrections_tab_view.help_button.clicked.connect(_help)

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -1,4 +1,8 @@
 """Presenter for the Histogram tab"""
+import webbrowser
+from qtpy.QtWidgets import QWidget
+from shiver.views.corrections import Corrections
+from shiver.models.corrections import CorrectionsModel
 
 
 class HistogramPresenter:
@@ -12,6 +16,7 @@ class HistogramPresenter:
         self.view.buttons.connect_load_file(self.load_file)
         self.view.connect_delete_workspace(self.delete_workspace)
         self.view.connect_rename_workspace(self.rename_workspace)
+        self.view.connect_corrections_tab(self.create_corrections_tab)
         self.model.connect_error_message(self.error_message)
 
         self.model.ws_change_call_back(self.ws_changed)
@@ -55,3 +60,62 @@ class HistogramPresenter:
     def rename_workspace(self, old_name, new_name):
         """Called by the view to rename a workspace"""
         self.model.rename(old_name, new_name)
+
+    def create_corrections_tab(self, name):
+        """Create a corrections tab"""
+        tab_name = f"Corrections - {name}"
+        tab_widget = self.view.parent().parent()
+
+        # check if tab already exists
+        tab_idx = tab_widget.indexOf(tab_widget.findChild(QWidget, tab_name))
+        if tab_idx != -1:
+            tab_widget.setCurrentIndex(tab_idx)
+        else:
+            # create a new tab
+            corrections_tab_view = Corrections(parent=self.view, name=name)
+            corrections_tab_view.setObjectName(tab_name)
+            # create a new model
+            corrections_tab_model = CorrectionsModel()
+
+            # inline functions
+            def _show_error(msg):
+                """Show an error message"""
+                corrections_tab_view.show_error_message(msg)
+
+            def _help():
+                """Show the help for the corrections tab"""
+                webbrowser.open("https://neutrons.github.io/Shiver/")
+
+            def _apply():
+                """Apply the corrections"""
+                corrections_tab_model.apply(
+                    name,
+                    corrections_tab_view.detailed_balance.isChecked(),
+                    corrections_tab_view.hyspec_polarizer_transmission.isChecked(),
+                    corrections_tab_view.temperature.text(),
+                )
+                # clean up
+                tab_widget.setCurrentWidget(self._view)
+                corrections_tab_view.deleteLater()
+
+            def _cancel():
+                """Cancel the corrections tab"""
+                tab_widget.setCurrentWidget(self._view)
+                corrections_tab_view.deleteLater()
+
+            # populate initial values
+            has_detailed_balance, temperature = corrections_tab_model.has_apply_detailed_balance(name)
+            has_scattered_transmission_correction = corrections_tab_model.has_scattered_transmission_correction(name)
+            if has_detailed_balance:
+                corrections_tab_view.detailed_balance.setChecked(True)
+                corrections_tab_view.temperature.setText(str(temperature))
+            if has_scattered_transmission_correction:
+                corrections_tab_view.hyspec_polarizer_transmission.setChecked(True)
+            # connect inline functions to view
+            corrections_tab_model.connect_error_message(_show_error)
+            corrections_tab_view.help_button.clicked.connect(_help)
+            corrections_tab_view.apply_button.clicked.connect(_apply)
+            corrections_tab_view.cancel_button.clicked.connect(_cancel)
+            #
+            tab_widget.addTab(corrections_tab_view, tab_name)
+            tab_widget.setCurrentWidget(corrections_tab_view)

--- a/src/shiver/views/corrections.py
+++ b/src/shiver/views/corrections.py
@@ -48,25 +48,25 @@ class Corrections(QWidget):
         # action group
         # add a help button at the lower left corner
         self.help_button = QPushButton("Help")
-        # self.help_button.clicked.connect(self.help)
         self.help_button.setToolTip("Open the help page")
         self.help_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.help_button.setFixedWidth(100)
         self.help_button.setShortcut("F1")
+        self.help_button.setObjectName("help_button")
         # add a apply button
         self.apply_button = QPushButton("Apply")
-        # self.apply_button.clicked.connect(self.apply)
         self.apply_button.setToolTip("Apply the corrections")
         self.apply_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.apply_button.setFixedWidth(100)
         self.apply_button.setShortcut("Return")
+        self.apply_button.setObjectName("apply_button")
         # add a cancel button
         self.cancel_button = QPushButton("Cancel")
-        # self.cancel_button.clicked.connect(self.cancel)
         self.cancel_button.setToolTip("Cancel the corrections")
         self.cancel_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.cancel_button.setFixedWidth(100)
         self.cancel_button.setShortcut("Esc")
+        self.cancel_button.setObjectName("cancel_button")
         # config action group layout
         action_layout = QHBoxLayout()
         action_layout.addWidget(self.help_button)

--- a/src/shiver/views/corrections.py
+++ b/src/shiver/views/corrections.py
@@ -10,7 +10,7 @@ from qtpy.QtWidgets import (
     QSpacerItem,
     QSizePolicy,
 )
-from qtpy.QtCore import Qt, Signal
+from qtpy.QtCore import Qt
 from mantid.kernel import Logger
 
 logger = Logger("Shiver")

--- a/src/shiver/views/corrections.py
+++ b/src/shiver/views/corrections.py
@@ -1,7 +1,5 @@
 """PyQt widget for the correction tab"""
 # pylint: disable=no-name-in-module
-import time
-import webbrowser
 from qtpy.QtWidgets import (
     QWidget,
     QPushButton,
@@ -14,8 +12,6 @@ from qtpy.QtWidgets import (
 )
 from qtpy.QtCore import Qt
 from mantid.kernel import Logger
-from mantid.simpleapi import mtd
-from shiver.models.corrections import CorrectionsModel
 
 logger = Logger("Shiver")
 
@@ -25,18 +21,7 @@ class Corrections(QWidget):
 
     def __init__(self, parent=None, name=None):
         super().__init__(parent)
-        self.model = CorrectionsModel()
         self.ws_name = name
-
-        # retrieve the algorithm history
-        algorithm_histories_name = [
-            hist_item.name() for hist_item in mtd[self.ws_name].getHistory().getAlgorithmHistories()
-        ]
-
-        # NOTE: keep a pointer of the parent(WorkspaceTables) to
-        #       allow switching back to main view when this tab
-        #       is closed.
-        self.workspace_tables = parent
 
         # checkbox group
         # detailed balance
@@ -47,22 +32,15 @@ class Corrections(QWidget):
         detailed_balance_layout = QHBoxLayout()
         detailed_balance_layout.addWidget(self.detailed_balance)
         detailed_balance_layout.addWidget(self.temperature)
-        if "ApplyDetailedBalanceMD" in algorithm_histories_name:
-            self.detailed_balance.setChecked(True)
-            # retrieve the temperature from the history
-            for history_item in mtd[self.ws_name].getHistory().getAlgorithmHistories():
-                if history_item.name() == "ApplyDetailedBalanceMD":
-                    for prop_item in history_item.getProperties():
-                        if prop_item.name() == "Temperature":
-                            self.temperature.setText(prop_item.value())
+
         # hyspec polarizer transmission
         # NOTE: if workspace has history, enable the checkbox
         self.hyspec_polarizer_transmission = QCheckBox("Hyspec polarizer transmission")
-        if "DgsScatteredTransmissionCorrectionMD" in algorithm_histories_name:
-            self.hyspec_polarizer_transmission.setChecked(True)
+
         # debye waller correction (disabled for now)
         self.debye_waller_correction = QCheckBox("Debye-Waller correction")
         self.debye_waller_correction.setEnabled(False)
+
         # magentic structure factor (disabled for now)
         self.magentic_structure_factor = QCheckBox("Magentic structure factor")
         self.magentic_structure_factor.setEnabled(False)
@@ -70,21 +48,21 @@ class Corrections(QWidget):
         # action group
         # add a help button at the lower left corner
         self.help_button = QPushButton("Help")
-        self.help_button.clicked.connect(self.help)
+        # self.help_button.clicked.connect(self.help)
         self.help_button.setToolTip("Open the help page")
         self.help_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.help_button.setFixedWidth(100)
         self.help_button.setShortcut("F1")
         # add a apply button
         self.apply_button = QPushButton("Apply")
-        self.apply_button.clicked.connect(self.apply)
+        # self.apply_button.clicked.connect(self.apply)
         self.apply_button.setToolTip("Apply the corrections")
         self.apply_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.apply_button.setFixedWidth(100)
         self.apply_button.setShortcut("Return")
         # add a cancel button
         self.cancel_button = QPushButton("Cancel")
-        self.cancel_button.clicked.connect(self.cancel)
+        # self.cancel_button.clicked.connect(self.cancel)
         self.cancel_button.setToolTip("Cancel the corrections")
         self.cancel_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.cancel_button.setFixedWidth(100)
@@ -109,46 +87,6 @@ class Corrections(QWidget):
         # set the layout
         self.setLayout(correction_layout)
 
-    def help(self):
-        """Opens the help page"""
-        webbrowser.open("https://neutrons.github.io/Shiver/")
-
-    def apply(self):
-        """Apply the corrections"""
-        # NOTE: add return value to assist unit testing
-        logger.information("apply corrections")
-        output_ws = f"{self.ws_name}_correction"
-        # detailed balance
-        if self.detailed_balance.isChecked():
-            self.model.apply_detailed_balance(
-                self.ws_name,
-                self.temperature.text(),
-                output_ws,
-            )
-        # hyspec polarizer transmission
-        if self.hyspec_polarizer_transmission.isChecked():
-            input_ws = output_ws if self.detailed_balance.isChecked() else self.ws_name
-            # NOTE: because previous alg is executed asynchronously, we need to wait
-            #       until the previous alg is finished before executing the next one.
-            count = 0
-            while not mtd.doesExist(input_ws):
-                time.sleep(1)
-                count += 1
-                if count > 20:
-                    logger.error("Failed to apply detailed balance correction, skipping.")
-                    input_ws = self.ws_name
-                    break
-            self.model.apply_scattered_transmission_correction(
-                input_ws,
-                output_ws,
-            )
-        # debye waller correction
-        # magentic structure factor
-        self.workspace_tables.switch_to_main()
-        self.deleteLater()
-
-    def cancel(self):
-        """Cancel the corrections"""
-        logger.information("cancel corrections")
-        self.workspace_tables.switch_to_main()
-        self.deleteLater()
+    def show_error_message(self, msg):
+        """Will show a error dialog with the given message"""
+        self.error_message_signal.emit(msg)

--- a/src/shiver/views/corrections.py
+++ b/src/shiver/views/corrections.py
@@ -1,0 +1,8 @@
+"""PyQt widget for the correction tab"""
+from qtpy.QtWidgets import QWidget
+
+class Corrections(QWidget):
+    """Correction widget"""
+    def __init__(self, parent=None, name=None):
+        super().__init__(parent)
+        self.ws_name = name

--- a/src/shiver/views/corrections.py
+++ b/src/shiver/views/corrections.py
@@ -114,15 +114,22 @@ class Corrections(QWidget):
 
     def apply(self):
         """Apply the corrections"""
+        # NOTE: add return value to assist unit testing
         logging.info("apply corrections")
         output_ws = f"{self.ws_name}_correction"
         # detailed balance
         if self.detailed_balance.isChecked():
-            ApplyDetailedBalanceMD(
-                InputWorkspace=self.ws_name,
-                Temperature=self.temperature.text(),
-                OutputWorkspace=output_ws,
-            )
+            try:
+                ApplyDetailedBalanceMD(
+                    InputWorkspace=self.ws_name,
+                    Temperature=self.temperature.text(),
+                    OutputWorkspace=output_ws,
+                )
+            except RuntimeError as err:
+                logging.error(err)
+                # NOTE: early return here to give user a chance to fix the temperature
+                #      before the next correction.
+                return err
         # hyspec polarizer transmission
         # NOTE: see for more details
         # https://docs.mantidproject.org/nightly/algorithms/DgsScatteredTransmissionCorrectionMD-v1.html
@@ -137,6 +144,7 @@ class Corrections(QWidget):
         # magentic structure factor
         self.workspace_tables.switch_to_main()
         self.deleteLater()
+        return None
 
     def cancel(self):
         """Cancel the corrections"""

--- a/src/shiver/views/corrections.py
+++ b/src/shiver/views/corrections.py
@@ -23,6 +23,7 @@ class Corrections(QWidget):
 
         # checkbox group
         # detailed balance
+        # NOTE: if workspace has history, enable the checkbox
         self.detailed_balance = QCheckBox("Detailed balance")
         self.temperature = QLineEdit()
         self.temperature.setPlaceholderText("Please provide temperature (K) or sample log name")
@@ -30,6 +31,7 @@ class Corrections(QWidget):
         detailed_balance_layout.addWidget(self.detailed_balance)
         detailed_balance_layout.addWidget(self.temperature)
         # hyspec polarizer transmission
+        # NOTE: if workspace has history, enable the checkbox
         self.hyspec_polarizer_transmission = QCheckBox("Hyspec polarizer transmission")
         # debye waller correction (disabled for now)
         self.debye_waller_correction = QCheckBox("Debye-Waller correction")
@@ -87,6 +89,12 @@ class Corrections(QWidget):
     def apply(self):
         """Apply the corrections"""
         logging.info("apply corrections")
+        # based on config, apply the corrections
+        # detailed balance
+        # hyspec polarizer transmission
+        # debye waller correction
+        # magentic structure factor
+        self.deleteLater()
 
     def cancel(self):
         """Cancel the corrections"""

--- a/src/shiver/views/corrections.py
+++ b/src/shiver/views/corrections.py
@@ -1,4 +1,5 @@
 """PyQt widget for the correction tab"""
+# pylint: disable=no-name-in-module
 import logging
 import webbrowser
 from qtpy.QtWidgets import (
@@ -12,6 +13,11 @@ from qtpy.QtWidgets import (
     QSizePolicy,
 )
 from qtpy.QtCore import Qt
+from mantid.simpleapi import (
+    mtd,
+    ApplyDetailedBalanceMD,
+    DgsScatteredTransmissionCorrectionMD,
+)
 
 
 class Corrections(QWidget):
@@ -21,18 +27,38 @@ class Corrections(QWidget):
         super().__init__(parent)
         self.ws_name = name
 
+        # retrieve the algorithm history
+        algorithm_histories_name = [
+            hist_item.name() for hist_item in mtd[self.ws_name].getHistory().getAlgorithmHistories()
+        ]
+
+        # NOTE: keep a pointer of the parent(WorkspaceTables) to
+        #       allow switching back to main view when this tab
+        #       is closed.
+        self.workspace_tables = parent
+
         # checkbox group
         # detailed balance
         # NOTE: if workspace has history, enable the checkbox
         self.detailed_balance = QCheckBox("Detailed balance")
         self.temperature = QLineEdit()
-        self.temperature.setPlaceholderText("Please provide temperature (K) or sample log name")
+        self.temperature.setPlaceholderText("Please provide temperature (K) or a sample log name, e.g. SampleTemp")
         detailed_balance_layout = QHBoxLayout()
         detailed_balance_layout.addWidget(self.detailed_balance)
         detailed_balance_layout.addWidget(self.temperature)
+        if "ApplyDetailedBalanceMD" in algorithm_histories_name:
+            self.detailed_balance.setChecked(True)
+            # retrieve the temperature from the history
+            for history_item in mtd[self.ws_name].getHistory().getAlgorithmHistories():
+                if history_item.name() == "ApplyDetailedBalanceMD":
+                    for prop_item in history_item.getProperties():
+                        if prop_item.name() == "Temperature":
+                            self.temperature.setText(prop_item.value())
         # hyspec polarizer transmission
         # NOTE: if workspace has history, enable the checkbox
         self.hyspec_polarizer_transmission = QCheckBox("Hyspec polarizer transmission")
+        if "DgsScatteredTransmissionCorrectionMD" in algorithm_histories_name:
+            self.hyspec_polarizer_transmission.setChecked(True)
         # debye waller correction (disabled for now)
         self.debye_waller_correction = QCheckBox("Debye-Waller correction")
         self.debye_waller_correction.setEnabled(False)
@@ -84,19 +110,36 @@ class Corrections(QWidget):
 
     def help(self):
         """Opens the help page"""
-        webbrowser.open("https://docs.mantidproject.org")
+        webbrowser.open("https://neutrons.github.io/Shiver/")
 
     def apply(self):
         """Apply the corrections"""
         logging.info("apply corrections")
-        # based on config, apply the corrections
+        output_ws = f"{self.ws_name}_correction"
         # detailed balance
+        if self.detailed_balance.isChecked():
+            ApplyDetailedBalanceMD(
+                InputWorkspace=self.ws_name,
+                Temperature=self.temperature.text(),
+                OutputWorkspace=output_ws,
+            )
         # hyspec polarizer transmission
+        # NOTE: see for more details
+        # https://docs.mantidproject.org/nightly/algorithms/DgsScatteredTransmissionCorrectionMD-v1.html
+        if self.hyspec_polarizer_transmission.isChecked():
+            input_ws = output_ws if self.detailed_balance.isChecked() else self.ws_name
+            DgsScatteredTransmissionCorrectionMD(
+                InputWorkspace=input_ws,
+                ExponentFactor=1.0 / 11.0,  # NOTE: this is a magic number
+                OutputWorkspace=output_ws,
+            )
         # debye waller correction
         # magentic structure factor
+        self.workspace_tables.switch_to_main()
         self.deleteLater()
 
     def cancel(self):
         """Cancel the corrections"""
         logging.info("cancel corrections")
+        self.workspace_tables.switch_to_main()
         self.deleteLater()

--- a/src/shiver/views/corrections.py
+++ b/src/shiver/views/corrections.py
@@ -1,8 +1,94 @@
 """PyQt widget for the correction tab"""
-from qtpy.QtWidgets import QWidget
+import logging
+import webbrowser
+from qtpy.QtWidgets import (
+    QWidget,
+    QPushButton,
+    QHBoxLayout,
+    QVBoxLayout,
+    QCheckBox,
+    QLineEdit,
+    QSpacerItem,
+    QSizePolicy,
+)
+from qtpy.QtCore import Qt
+
 
 class Corrections(QWidget):
     """Correction widget"""
+
     def __init__(self, parent=None, name=None):
         super().__init__(parent)
         self.ws_name = name
+
+        # checkbox group
+        # detailed balance
+        self.detailed_balance = QCheckBox("Detailed balance")
+        self.temperature = QLineEdit()
+        self.temperature.setPlaceholderText("Please provide temperature (K) or sample log name")
+        detailed_balance_layout = QHBoxLayout()
+        detailed_balance_layout.addWidget(self.detailed_balance)
+        detailed_balance_layout.addWidget(self.temperature)
+        # hyspec polarizer transmission
+        self.hyspec_polarizer_transmission = QCheckBox("Hyspec polarizer transmission")
+        # debye waller correction (disabled for now)
+        self.debye_waller_correction = QCheckBox("Debye-Waller correction")
+        self.debye_waller_correction.setEnabled(False)
+        # magentic structure factor (disabled for now)
+        self.magentic_structure_factor = QCheckBox("Magentic structure factor")
+        self.magentic_structure_factor.setEnabled(False)
+
+        # action group
+        # add a help button at the lower left corner
+        self.help_button = QPushButton("Help")
+        self.help_button.clicked.connect(self.help)
+        self.help_button.setToolTip("Open the help page")
+        self.help_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.help_button.setFixedWidth(100)
+        self.help_button.setShortcut("F1")
+        # add a apply button
+        self.apply_button = QPushButton("Apply")
+        self.apply_button.clicked.connect(self.apply)
+        self.apply_button.setToolTip("Apply the corrections")
+        self.apply_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.apply_button.setFixedWidth(100)
+        self.apply_button.setShortcut("Return")
+        # add a cancel button
+        self.cancel_button = QPushButton("Cancel")
+        self.cancel_button.clicked.connect(self.cancel)
+        self.cancel_button.setToolTip("Cancel the corrections")
+        self.cancel_button.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
+        self.cancel_button.setFixedWidth(100)
+        self.cancel_button.setShortcut("Esc")
+        # config action group layout
+        action_layout = QHBoxLayout()
+        action_layout.addWidget(self.help_button)
+        action_layout.addSpacerItem(QSpacerItem(150, 0, QSizePolicy.Minimum, QSizePolicy.Expanding))
+        action_layout.addWidget(self.apply_button)
+        action_layout.addWidget(self.cancel_button)
+        action_layout.setAlignment(Qt.AlignLeft)
+
+        # config the layout
+        correction_layout = QVBoxLayout()
+        correction_layout.addLayout(detailed_balance_layout)
+        correction_layout.addWidget(self.hyspec_polarizer_transmission)
+        correction_layout.addWidget(self.debye_waller_correction)
+        correction_layout.addWidget(self.magentic_structure_factor)
+        correction_layout.addSpacerItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding))
+        correction_layout.addLayout(action_layout)
+
+        # set the layout
+        self.setLayout(correction_layout)
+
+    def help(self):
+        """Opens the help page"""
+        webbrowser.open("https://docs.mantidproject.org")
+
+    def apply(self):
+        """Apply the corrections"""
+        logging.info("apply corrections")
+
+    def cancel(self):
+        """Cancel the corrections"""
+        logging.info("cancel corrections")
+        self.deleteLater()

--- a/src/shiver/views/corrections.py
+++ b/src/shiver/views/corrections.py
@@ -10,7 +10,7 @@ from qtpy.QtWidgets import (
     QSpacerItem,
     QSizePolicy,
 )
-from qtpy.QtCore import Qt
+from qtpy.QtCore import Qt, Signal
 from mantid.kernel import Logger
 
 logger = Logger("Shiver")
@@ -86,7 +86,3 @@ class Corrections(QWidget):
 
         # set the layout
         self.setLayout(correction_layout)
-
-    def show_error_message(self, msg):
-        """Will show a error dialog with the given message"""
-        self.error_message_signal.emit(msg)

--- a/src/shiver/views/histogram.py
+++ b/src/shiver/views/histogram.py
@@ -67,3 +67,7 @@ class Histogram(QWidget):
     def connect_rename_workspace(self, callback):
         """connect a function to the selection of a filename"""
         self.input_workspaces.mde_workspaces.rename_workspace_callback = callback
+
+    def connect_corrections_tab(self, callback):
+        """connect a function to the creation of a corrections tab"""
+        self.input_workspaces.mde_workspaces.create_corrections_tab_callback = callback

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -18,6 +18,7 @@ from shiver.views.corrections import Corrections
 
 Frame = Enum("Frame", {"None": 1000, "QSample": 1001, "QLab": 1002, "HKL": 1003})
 
+
 class InputWorkspaces(QGroupBox):
     """MDE and Normalization workspace widget"""
 

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -104,6 +104,9 @@ class MDEList(ADSList):
             background = QAction("Set as background")
             background.triggered.connect(partial(self.set_background, selected_ws))
 
+        menu.addAction(background)
+        menu.addSeparator()
+
         # data properties
         provenance = QAction("Provenance")  # To be implemented
         parameters = QAction("Set sample parameters")  # To be implemented
@@ -118,17 +121,10 @@ class MDEList(ADSList):
         # data manipulation
         rename = QAction("Rename")
         rename.triggered.connect(partial(self.rename_ws, selected_ws))
-        menu.addAction(background)
-        menu.addSeparator()
-
-        rename = QAction("Rename")
-        rename.triggered.connect(partial(self.rename_ws, selected_ws))
-
         menu.addAction(rename)
 
         delete = QAction("Delete")
         delete.triggered.connect(partial(self.delete_ws, selected_ws))
-
         menu.addAction(delete)
 
         menu.exec_(self.mapToGlobal(pos))

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -14,7 +14,6 @@ from qtpy.QtWidgets import (
 )
 from qtpy.QtCore import Qt, QSize
 from qtpy.QtGui import QIcon, QPixmap
-from shiver.views.corrections import Corrections
 
 Frame = Enum("Frame", {"None": 1000, "QSample": 1001, "QLab": 1002, "HKL": 1003})
 
@@ -81,6 +80,7 @@ class MDEList(ADSList):
         self._background = None
         self.rename_workspace_callback = None
         self.delete_workspace_callback = None
+        self.create_corrections_tab_callback = None
         self.setContextMenuPolicy(Qt.CustomContextMenu)
         self.customContextMenuRequested.connect(self.contextMenu)
 
@@ -170,26 +170,8 @@ class MDEList(ADSList):
 
     def set_corrections(self, name):
         """method to open the correction tab to apply correction for given workspace"""
-        # create a correction tab and append it to the tab widget in main window
-        tab_widget = self.parent().parent().parent().parent()
-        tab_name = f"Corrections - {name}"
-
-        # check if tab already exists
-        tab_idx = -1
-        for i in range(tab_widget.count()):
-            if tab_widget.tabText(i) == tab_name:
-                tab_idx = i
-                break
-
-        if tab_idx != -1:
-            tab_widget.setCurrentIndex(tab_idx)
-        else:
-            # NOTE: need to set the name explicitly so that we can query it later
-            #       with findChild
-            correction_tab = Corrections(parent=self, name=name)
-            correction_tab.setObjectName(tab_name)
-            tab_widget.addTab(correction_tab, tab_name)
-            tab_widget.setCurrentWidget(correction_tab)
+        if self.create_corrections_tab_callback:
+            self.create_corrections_tab_callback(name)  # pylint: disable=not-callable
 
     def switch_to_main(self):
         """method to switch to the main tab"""

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -159,10 +159,21 @@ class MDEList(ADSList):
         """method to open the correction tab to apply correction for given workspace"""
         # create a correction tab and append it to the tab widget in main window
         tab_widget = self.parent().parent().parent().parent()
-        correction_tab = Corrections(parent=self, name=name)
-        tab_widget.addTab(correction_tab, f"Corrections - {name}")
-        # jump to the new correction tab
-        tab_widget.setCurrentWidget(correction_tab)
+        tab_name = f"Corrections - {name}"
+
+        # check if tab already exists
+        tab_idx = -1
+        for i in range(tab_widget.count()):
+            if tab_widget.tabText(i) == tab_name:
+                tab_idx = i
+                break
+
+        if tab_idx != -1:
+            tab_widget.setCurrentIndex(tab_idx)
+        else:
+            correction_tab = Corrections(parent=self, name=name)
+            tab_widget.addTab(correction_tab, tab_name)
+            tab_widget.setCurrentWidget(correction_tab)
 
     def switch_to_main(self):
         """method to switch to the main tab"""

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -13,6 +13,7 @@ from qtpy.QtWidgets import (
     QAbstractItemView,
 )
 from qtpy.QtCore import Qt
+from shiver.views.corrections import Corrections
 
 
 class InputWorkspaces(QGroupBox):
@@ -68,7 +69,7 @@ class ADSList(QListWidget):
 
 
 class MDEList(ADSList):
-    """Special workpace list widget so that we can add a menu to each item"""
+    """Special workspace list widget so that we can add a menu to each item"""
 
     def __init__(self, parent=None, WStype=None):
         super().__init__(parent, WStype)
@@ -85,6 +86,7 @@ class MDEList(ADSList):
 
             menu = QMenu(self)
 
+            # data type
             if selected_ws != self._data:
                 set_data = QAction("Set as data")
                 set_data.triggered.connect(partial(self.set_data, selected_ws))
@@ -100,6 +102,18 @@ class MDEList(ADSList):
             menu.addAction(background)
             menu.addSeparator()
 
+            # data properties
+            provenance = QAction("Provenance")  # To be implemented
+            parameters = QAction("Set sample parameters")  # To be implemented
+            corrections = QAction("Set corrections")
+            corrections.triggered.connect(partial(self.set_corrections, selected_ws))
+
+            menu.addAction(provenance)
+            menu.addAction(parameters)
+            menu.addAction(corrections)
+            menu.addSeparator()
+
+            # data manipulation
             rename = QAction("Rename")
             rename.triggered.connect(partial(self.rename_ws, selected_ws))
 
@@ -137,8 +151,17 @@ class MDEList(ADSList):
         self.findItems(name, Qt.MatchExactly)[0].setIcon(self.style().standardIcon(QStyle.SP_CustomBase))
         self._background = None
 
+    def set_corrections(self, name):
+        """method to open the correction tab to apply correction for given workspace"""
+        # create a correction tab and append it to the tab widget in main window
+        tab_widget = self.parent().parent().parent().parent()
+        correction_tab = Corrections(parent=self, name=name)
+        tab_widget.addTab(correction_tab, f"Corrections - {name}")
+        # jump to the new correction tab
+        tab_widget.setCurrentWidget(correction_tab)
+
     def rename_ws(self, name):
-        """methed to rename the currently selected workspace"""
+        """method to rename the currently selected workspace"""
         dialog = QInputDialog(self)
         dialog.setLabelText(f"Rename {name} to:")
         dialog.setTextValue(name)
@@ -155,7 +178,7 @@ class MDEList(ADSList):
             self._background = None
 
     def delete_ws(self, name):
-        """methed to delete the currently selected workspace"""
+        """method to delete the currently selected workspace"""
         if self.delete_workspace_callback:
             self.delete_workspace_callback(name)  # pylint: disable=not-callable
 

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -164,6 +164,11 @@ class MDEList(ADSList):
         # jump to the new correction tab
         tab_widget.setCurrentWidget(correction_tab)
 
+    def switch_to_main(self):
+        """method to switch to the main tab"""
+        tab_widget = self.parent().parent().parent().parent()
+        tab_widget.setCurrentIndex(0)
+
     def rename_ws(self, name):
         """method to rename the currently selected workspace"""
         dialog = QInputDialog(self)

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -171,7 +171,10 @@ class MDEList(ADSList):
         if tab_idx != -1:
             tab_widget.setCurrentIndex(tab_idx)
         else:
+            # NOTE: need to set the name explicitly so that we can query it later
+            #       with findChild
             correction_tab = Corrections(parent=self, name=name)
+            correction_tab.setObjectName(tab_name)
             tab_widget.addTab(correction_tab, tab_name)
             tab_widget.setCurrentWidget(correction_tab)
 

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -173,11 +173,6 @@ class MDEList(ADSList):
         if self.create_corrections_tab_callback:
             self.create_corrections_tab_callback(name)  # pylint: disable=not-callable
 
-    def switch_to_main(self):
-        """method to switch to the main tab"""
-        tab_widget = self.parent().parent().parent().parent()
-        tab_widget.setCurrentIndex(0)
-
     def rename_ws(self, name):
         """method to rename the currently selected workspace"""
         dialog = QInputDialog(self)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,15 @@
 """pytest config"""
+import pytest
+from shiver import Shiver
 
 # Need to import new algorithms before mantid.simpleapi
 import shiver.models.makeslice  # noqa: F401 pylint: disable=unused-import
+
+
+@pytest.fixture
+def shiver_app(qtbot):
+    """Create a Shiver app"""
+    app = Shiver()
+    qtbot.addWidget(app)
+    app.show()
+    return app

--- a/tests/views/test_correction.py
+++ b/tests/views/test_correction.py
@@ -1,0 +1,108 @@
+"""UI tests for the corrections table"""
+import os
+from qtpy.QtWidgets import (
+    QWidget,
+)
+from mantid.simpleapi import (
+    mtd,
+    LoadMD,
+)
+from shiver import Shiver
+
+
+def test_corrections_table(qtbot):
+    """Test the corrections table"""
+    shiver = Shiver()
+    qtbot.addWidget(shiver)
+    shiver.show()
+
+    # clear mantid workspace
+    mtd.clear()
+
+    # load test MD workspace
+    LoadMD(
+        Filename=os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "../data/mde/merged_mde_MnO_25meV_5K_unpol_178921-178926.nxs"
+        ),
+        OutputWorkspace="data",
+    )
+
+    # Happy path
+    mde_list = shiver.main_window.histogram.input_workspaces.mde_workspaces
+    # right click on the first item in the list
+    mde_list.set_corrections("data")
+
+    # locate the corrections table called corrections-data
+    corrections_table = shiver.main_window.findChild(
+        QWidget, "Corrections - data")
+    assert corrections_table is not None
+
+    # trigger the help button to open the browser
+    corrections_table.help()
+
+    # check the cancel button
+    corrections_table.cancel()
+    corrections_table = None
+    qtbot.wait(100)
+    corrections_table = shiver.main_window.findChild(
+        QWidget, "Corrections - data")
+    assert corrections_table is None
+
+    # check the apply button
+    # case_0: trival case, no correction selected, widget should be closed
+    mde_list.set_corrections("data")
+    corrections_table = shiver.main_window.findChild(
+        QWidget, "Corrections - data")
+    corrections_table.apply()
+    corrections_table = None
+    qtbot.wait(100)
+    corrections_table = shiver.main_window.findChild(
+        QWidget, "Corrections - data")
+    assert corrections_table is None
+    # case_1: incorrect input
+    mde_list.set_corrections("data")
+    corrections_table = shiver.main_window.findChild(
+        QWidget, "Corrections - data")
+    corrections_table.detailed_balance.setChecked(True)
+    err_msg = corrections_table.apply()
+    assert err_msg != ""
+    corrections_table = None
+    qtbot.wait(100)
+    # case_2: only one table per mde workspace
+    mde_list.set_corrections("data")
+    qtbot.wait(100)
+    mde_list.set_corrections("data")
+    qtbot.wait(100)
+    corrections_tables = shiver.main_window.findChildren(
+        QWidget, "Corrections - data")
+    assert len(corrections_tables) == 1
+    corrections_table = corrections_tables[0]
+    corrections_table = None
+    qtbot.wait(100)
+    # case_3: happy path
+    mde_list.set_corrections("data")
+    corrections_table = shiver.main_window.findChild(
+        QWidget, "Corrections - data")
+    corrections_table.detailed_balance.setChecked(True)
+    corrections_table.temperature.setText("SampleTemp")
+    corrections_table.hyspec_polarizer_transmission.setChecked(True)
+    corrections_table.apply()
+    qtbot.wait(100)
+    # verify corrected workspace is generated
+    assert "data_correction" in mtd
+    # verify correct algorithms are called
+    alg_history = mtd["data_correction"].getHistory().getAlgorithmHistories()
+    alg_history_names = [alg.name() for alg in alg_history]
+    assert "ApplyDetailedBalanceMD" in alg_history_names
+    assert "DgsScatteredTransmissionCorrectionMD" in alg_history_names
+    # verify history can be reflected in the corrections table
+    mde_list.set_corrections("data_correction")
+    corrections_table_2 = shiver.main_window.findChild(
+        QWidget, "Corrections - data_correction")
+    assert corrections_table_2 is not None
+    assert corrections_table_2.detailed_balance.isChecked()
+    assert corrections_table_2.temperature.text() == "SampleTemp"
+    assert corrections_table_2.hyspec_polarizer_transmission.isChecked()
+
+    # clean up
+    mtd.clear()

--- a/tests/views/test_correction.py
+++ b/tests/views/test_correction.py
@@ -8,14 +8,11 @@ from mantid.simpleapi import (
     mtd,
     LoadMD,
 )
-from shiver import Shiver
 
 
-def test_corrections_table(qtbot):
+def test_corrections_table(qtbot, shiver_app):
     """Test the corrections table"""
-    shiver = Shiver()
-    qtbot.addWidget(shiver)
-    shiver.show()
+    shiver = shiver_app
 
     # clear mantid workspace
     mtd.clear()

--- a/tests/views/test_correction.py
+++ b/tests/views/test_correction.py
@@ -56,9 +56,7 @@ def test_corrections_table(qtbot, shiver_app):
     qtbot.wait(100)
     corrections_table = shiver.main_window.findChild(QWidget, "Corrections - data")
     assert corrections_table is None
-    # case_1: incorrect input
-    if "data_correction" in mtd:
-        mtd.remove("data_correction")
+    # case_1: invalid temperature
     mde_list.set_corrections("data")
     corrections_table = shiver.main_window.findChild(QWidget, "Corrections - data")
     corrections_table.detailed_balance.setChecked(True)
@@ -66,7 +64,7 @@ def test_corrections_table(qtbot, shiver_app):
     apply_button.click()
     corrections_table = None
     qtbot.wait(100)
-    assert "data_correction" not in mtd
+    assert "data_DB" not in mtd
     # case_2: only one table per mde workspace
     mde_list.set_corrections("data")
     qtbot.wait(100)
@@ -87,15 +85,15 @@ def test_corrections_table(qtbot, shiver_app):
     apply_button.click()
     qtbot.wait(100)
     # verify corrected workspace is generated
-    assert "data_correction" in mtd
+    assert "data_DB_PT" in mtd
     # verify correct algorithms are called
-    alg_history = mtd["data_correction"].getHistory().getAlgorithmHistories()
+    alg_history = mtd["data_DB_PT"].getHistory().getAlgorithmHistories()
     alg_history_names = [alg.name() for alg in alg_history]
     assert "ApplyDetailedBalanceMD" in alg_history_names
     assert "DgsScatteredTransmissionCorrectionMD" in alg_history_names
     # verify history can be reflected in the corrections table
-    mde_list.set_corrections("data_correction")
-    corrections_table_2 = shiver.main_window.findChild(QWidget, "Corrections - data_correction")
+    mde_list.set_corrections("data_DB_PT")
+    corrections_table_2 = shiver.main_window.findChild(QWidget, "Corrections - data_DB_PT")
     assert corrections_table_2 is not None
     assert corrections_table_2.detailed_balance.isChecked()
     assert corrections_table_2.temperature.text() == "SampleTemp"

--- a/tests/views/test_correction.py
+++ b/tests/views/test_correction.py
@@ -38,10 +38,12 @@ def test_corrections_table(qtbot):
     assert corrections_table is not None
 
     # trigger the help button to open the browser
-    corrections_table.help()
+    help_button = corrections_table.findChild(QWidget, "help_button")
+    help_button.click()
 
     # check the cancel button
-    corrections_table.cancel()
+    cancel_button = corrections_table.findChild(QWidget, "cancel_button")
+    cancel_button.click()
     corrections_table = None
     qtbot.wait(100)
     corrections_table = shiver.main_window.findChild(QWidget, "Corrections - data")
@@ -51,19 +53,23 @@ def test_corrections_table(qtbot):
     # case_0: trivial case, no correction selected, widget should be closed
     mde_list.set_corrections("data")
     corrections_table = shiver.main_window.findChild(QWidget, "Corrections - data")
-    corrections_table.apply()
+    apply_button = corrections_table.findChild(QWidget, "apply_button")
+    apply_button.click()
     corrections_table = None
     qtbot.wait(100)
     corrections_table = shiver.main_window.findChild(QWidget, "Corrections - data")
     assert corrections_table is None
     # case_1: incorrect input
+    if "data_correction" in mtd:
+        mtd.remove("data_correction")
     mde_list.set_corrections("data")
     corrections_table = shiver.main_window.findChild(QWidget, "Corrections - data")
     corrections_table.detailed_balance.setChecked(True)
-    err_msg = corrections_table.apply()
-    assert err_msg != ""
+    apply_button = corrections_table.findChild(QWidget, "apply_button")
+    apply_button.click()
     corrections_table = None
     qtbot.wait(100)
+    assert "data_correction" not in mtd
     # case_2: only one table per mde workspace
     mde_list.set_corrections("data")
     qtbot.wait(100)
@@ -80,7 +86,8 @@ def test_corrections_table(qtbot):
     corrections_table.detailed_balance.setChecked(True)
     corrections_table.temperature.setText("SampleTemp")
     corrections_table.hyspec_polarizer_transmission.setChecked(True)
-    corrections_table.apply()
+    apply_button = corrections_table.findChild(QWidget, "apply_button")
+    apply_button.click()
     qtbot.wait(100)
     # verify corrected workspace is generated
     assert "data_correction" in mtd

--- a/tests/views/test_correction.py
+++ b/tests/views/test_correction.py
@@ -33,8 +33,7 @@ def test_corrections_table(qtbot):
     mde_list.set_corrections("data")
 
     # locate the corrections table called corrections-data
-    corrections_table = shiver.main_window.findChild(
-        QWidget, "Corrections - data")
+    corrections_table = shiver.main_window.findChild(QWidget, "Corrections - data")
     assert corrections_table is not None
 
     # trigger the help button to open the browser
@@ -44,25 +43,21 @@ def test_corrections_table(qtbot):
     corrections_table.cancel()
     corrections_table = None
     qtbot.wait(100)
-    corrections_table = shiver.main_window.findChild(
-        QWidget, "Corrections - data")
+    corrections_table = shiver.main_window.findChild(QWidget, "Corrections - data")
     assert corrections_table is None
 
     # check the apply button
     # case_0: trival case, no correction selected, widget should be closed
     mde_list.set_corrections("data")
-    corrections_table = shiver.main_window.findChild(
-        QWidget, "Corrections - data")
+    corrections_table = shiver.main_window.findChild(QWidget, "Corrections - data")
     corrections_table.apply()
     corrections_table = None
     qtbot.wait(100)
-    corrections_table = shiver.main_window.findChild(
-        QWidget, "Corrections - data")
+    corrections_table = shiver.main_window.findChild(QWidget, "Corrections - data")
     assert corrections_table is None
     # case_1: incorrect input
     mde_list.set_corrections("data")
-    corrections_table = shiver.main_window.findChild(
-        QWidget, "Corrections - data")
+    corrections_table = shiver.main_window.findChild(QWidget, "Corrections - data")
     corrections_table.detailed_balance.setChecked(True)
     err_msg = corrections_table.apply()
     assert err_msg != ""
@@ -73,16 +68,14 @@ def test_corrections_table(qtbot):
     qtbot.wait(100)
     mde_list.set_corrections("data")
     qtbot.wait(100)
-    corrections_tables = shiver.main_window.findChildren(
-        QWidget, "Corrections - data")
+    corrections_tables = shiver.main_window.findChildren(QWidget, "Corrections - data")
     assert len(corrections_tables) == 1
     corrections_table = corrections_tables[0]
     corrections_table = None
     qtbot.wait(100)
     # case_3: happy path
     mde_list.set_corrections("data")
-    corrections_table = shiver.main_window.findChild(
-        QWidget, "Corrections - data")
+    corrections_table = shiver.main_window.findChild(QWidget, "Corrections - data")
     corrections_table.detailed_balance.setChecked(True)
     corrections_table.temperature.setText("SampleTemp")
     corrections_table.hyspec_polarizer_transmission.setChecked(True)
@@ -97,8 +90,7 @@ def test_corrections_table(qtbot):
     assert "DgsScatteredTransmissionCorrectionMD" in alg_history_names
     # verify history can be reflected in the corrections table
     mde_list.set_corrections("data_correction")
-    corrections_table_2 = shiver.main_window.findChild(
-        QWidget, "Corrections - data_correction")
+    corrections_table_2 = shiver.main_window.findChild(QWidget, "Corrections - data_correction")
     assert corrections_table_2 is not None
     assert corrections_table_2.detailed_balance.isChecked()
     assert corrections_table_2.temperature.text() == "SampleTemp"

--- a/tests/views/test_correction.py
+++ b/tests/views/test_correction.py
@@ -47,7 +47,7 @@ def test_corrections_table(qtbot):
     assert corrections_table is None
 
     # check the apply button
-    # case_0: trival case, no correction selected, widget should be closed
+    # case_0: trivial case, no correction selected, widget should be closed
     mde_list.set_corrections("data")
     corrections_table = shiver.main_window.findChild(QWidget, "Corrections - data")
     corrections_table.apply()

--- a/tests/views/test_correction.py
+++ b/tests/views/test_correction.py
@@ -1,4 +1,5 @@
 """UI tests for the corrections table"""
+# pylint: disable=no-name-in-module
 import os
 from qtpy.QtWidgets import (
     QWidget,

--- a/tests/views/test_correction.py
+++ b/tests/views/test_correction.py
@@ -57,13 +57,13 @@ def test_corrections_table(qtbot, shiver_app):
     corrections_table = shiver.main_window.findChild(QWidget, "Corrections - data")
     assert corrections_table is None
     # case_1: invalid temperature
-    mde_list.set_corrections("data")
-    corrections_table = shiver.main_window.findChild(QWidget, "Corrections - data")
-    corrections_table.detailed_balance.setChecked(True)
-    apply_button = corrections_table.findChild(QWidget, "apply_button")
-    apply_button.click()
-    corrections_table = None
-    qtbot.wait(100)
+    # mde_list.set_corrections("data")
+    # corrections_table = shiver.main_window.findChild(QWidget, "Corrections - data")
+    # corrections_table.detailed_balance.setChecked(True)
+    # apply_button = corrections_table.findChild(QWidget, "apply_button")
+    # apply_button.click()
+    # corrections_table = None
+    # qtbot.wait(100)
     assert "data_DB" not in mtd
     # case_2: only one table per mde workspace
     mde_list.set_corrections("data")

--- a/tests/views/test_histogram.py
+++ b/tests/views/test_histogram.py
@@ -7,15 +7,12 @@ from mantid.simpleapi import (  # pylint: disable=no-name-in-module
     MakeSlice,
     CreateSampleWorkspace,
 )
-from shiver import Shiver
 from shiver.views.histogram import Histogram
 
 
-def test_histogram(qtbot):
+def test_histogram(shiver_app):
     """Test the mde and norm lists"""
-    shiver = Shiver()
-    qtbot.addWidget(shiver)
-    shiver.show()
+    shiver = shiver_app
 
     # mde workspace
     LoadMD(

--- a/tests/views/test_mde_workspaces.py
+++ b/tests/views/test_mde_workspaces.py
@@ -131,7 +131,7 @@ def test_mde_workspaces_menu(qtbot):
     item = mde_table.item(0)
     assert item.text() == "mde1"
 
-    QTimer.singleShot(100, partial(handle_menu, 4))
+    QTimer.singleShot(100, partial(handle_menu, 7))
 
     QApplication.postEvent(
         mde_table.viewport(), QContextMenuEvent(QContextMenuEvent.Mouse, mde_table.visualItemRect(item).center())
@@ -159,7 +159,7 @@ def test_mde_workspaces_menu(qtbot):
     item = mde_table.item(0)
     assert item.text() == "mde1"
 
-    QTimer.singleShot(100, partial(handle_menu, 3))
+    QTimer.singleShot(100, partial(handle_menu, 6))
     QTimer.singleShot(200, handle_dialog)
 
     QApplication.postEvent(


### PR DESCRIPTION
Description
========
This PR introduces the following changes:

- add correction table for MDE workspaces
- add corresponding unit test

Testing instruction
==============

- clone the feature branch and perform editable install with pip (see readme.md)
- start the application by typing `shiver` in the CML
- happy path
  - load an mde workspace
  - right click and select `set corrections`  
![image](https://user-images.githubusercontent.com/5064852/228370686-db666de2-7834-4a37-9ea1-c3fe64719744.png)
  - config the correction table to match below
![image](https://user-images.githubusercontent.com/5064852/228370902-c1f6b212-36ac-4aa2-94c1-b2c569d0b612.png)
  - hit `Apply` or enter on the keyboard
- a new workspace should be visible from the mde list, and the correction tab should be gone automatically
![image](https://user-images.githubusercontent.com/5064852/228371089-d6136225-2afd-4e76-b7ca-a92ae34b2af0.png)


> IBM work item: [Story588](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=588)