### PR TITLE
Make the main Shiver window a singleton

### DIFF
--- a/src/shiver/shiver.py
+++ b/src/shiver/shiver.py
@@ -9,6 +9,13 @@ from shiver.views.mainwindow import MainWindow
 class Shiver(QMainWindow):
     """Main Shiver window"""
 
+    __instance = None
+
+    def __new__(cls):
+        if Shiver.__instance is None:
+            Shiver.__instance = QMainWindow.__new__(cls)  # pylint: disable=no-value-for-parameter
+        return Shiver.__instance
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setWindowTitle("SHIVER")


### PR DESCRIPTION
This will fix issues where widgets are deleted after closing and the application crashing when reopening Shiver

If you start Shiver from the workbench, then close it and open it again, when you load a valid file you would get the following error:

```RuntimeError: CreateMDHistoWorkspace-v1: wrapped C/C++ object of type MDEList has been deleted
  at line 172 in '/home/rwp/src/DGS_SC_scripts/src/shiver/models/histogram.py'
  caused by line 167 in '/home/rwp/src/DGS_SC_scripts/src/shiver/models/histogram.py'
  caused by line 56 in '/home/rwp/src/DGS_SC_scripts/src/shiver/presenters/histogram.py'
  caused by line 55 in '/home/rwp/src/DGS_SC_scripts/src/shiver/views/histogram.py'
  caused by line 45 in '/home/rwp/src/DGS_SC_scripts/src/shiver/views/workspace_tables.py'
  caused by line 69 in '/home/rwp/src/DGS_SC_scripts/src/shiver/views/workspace_tables.py'
  File "/home/rwp/src/DGS_SC_scripts/add_mdh.py", line 3, in <module>
    CreateMDHistoWorkspace(
  File "/home/rwp/anaconda3/envs/shiver/lib/python3.8/site-packages/mantid/simpleapi.py", line 1077, in __call__
    raise RuntimeError(msg) from e
```

This fixes that.
