### PR TITLE
Enable auto swapping min/max/step and retain step value

### DIFF
--- a/src/shiver/views/histogram_parameters.py
+++ b/src/shiver/views/histogram_parameters.py
@@ -211,6 +211,20 @@ class HistogramParameter(QGroupBox):
         step_valid_state = self.dimensions.steps_valid_state()
         return self.projections_valid_state and len(self.dimensions.min_max_invalid_states) == 0 and step_valid_state
 
+    def projection_to_hkl(self, projection: str) -> str:
+        """Converts the projection to H,K,L
+
+        Arguments:
+            projection {str} -- projection
+
+        Returns:
+            str -- H,K,L
+        """
+        chars = ["H", "K", "L"]
+        vec = numpy.array(list(map(float, projection.split(","))))
+        index_max = numpy.argmax(numpy.abs(vec))
+        return "[" + ",".join([translation(x, chars[index_max]) for x in vec]) + "]"
+
     def gather_histogram_parameters(self) -> dict:
         """Gathers the histogram parameters
 
@@ -229,6 +243,14 @@ class HistogramParameter(QGroupBox):
             parameters["QDimension1"] = self.projection_v.text()
             parameters["QDimension2"] = self.projection_w.text()
 
+            # build the label text for each
+            ref_dict = {
+                self.projection_to_hkl(self.projection_u.text()): "QDimension0",
+                self.projection_to_hkl(self.projection_v.text()): "QDimension1",
+                self.projection_to_hkl(self.projection_w.text()): "QDimension2",
+                "DeltaE": "DeltaE",
+            }
+
             # dimensions 1-4
             # NOTE: the index of each combo box corresponds to the projections items
             #     i.e. QDimension0, QDimension1, QDimension2, DeltaE
@@ -238,8 +260,7 @@ class HistogramParameter(QGroupBox):
                 combo_max = self.combo_maxx[i]
                 combo_step = self.combo_stepx[i]
                 # parse each dimension combo box to update the parameter dictionary
-                combo_idx = combo_dim.currentIndex()
-                dim_name = "DeltaE" if combo_idx == 3 else f"QDimension{combo_idx}"
+                dim_name = ref_dict[combo_dim.currentText()]
                 dim_min = combo_min.text()
                 dim_max = combo_max.text()
                 # if step visible, then it is a binning parameter

--- a/src/shiver/views/histogram_parameters.py
+++ b/src/shiver/views/histogram_parameters.py
@@ -395,9 +395,9 @@ class HistogramParameter(QGroupBox):
             # finally, update the colors
             for step in self.required_steps:
                 if step.text() != "":
-                    step.setStyleSheet("background-color: #ffffff")
+                    step.setStyleSheet("QLineEdit { background-color: #ffffff }")
                 else:
-                    step.setStyleSheet("background-color: #ffaaaa")
+                    step.setStyleSheet("QLineEdit { background-color: #ffaaaa }")
 
 
 class Dimensions(QWidget):

--- a/src/shiver/views/histogram_parameters.py
+++ b/src/shiver/views/histogram_parameters.py
@@ -391,12 +391,13 @@ class HistogramParameter(QGroupBox):
             else:
                 # This should never happen
                 raise ValueError("Unknown dimension")
+
             # finally, update the colors
             for step in self.required_steps:
-                if step.text() == "":
-                    step.setStyleSheet("QLineEdit {{ background-color: #ffaaaa }}")
+                if step.text() != "":
+                    step.setStyleSheet("background-color: #ffffff")
                 else:
-                    step.setStyleSheet("QLineEdit {{ background-color: #ffffff }}")
+                    step.setStyleSheet("background-color: #ffaaaa")
 
 
 class Dimensions(QWidget):

--- a/tests/views/test_dimensions.py
+++ b/tests/views/test_dimensions.py
@@ -47,7 +47,7 @@ def test_dimensions_radio_btn(qtbot):
     assert histogram_parameters.dimensions.combo_step1.text() == "0.5"
     assert histogram_parameters.dimensions.combo_step2.text() == "0.2"
     assert histogram_parameters.dimensions.combo_step3.text() == "0.02"
-    assert histogram_parameters.dimensions.combo_step4.text() == ""
+    assert histogram_parameters.dimensions.combo_step4.text() == "2"
     assert histogram_parameters.dimensions.steps_valid_state() is True
 
     histogram_parameters.dimensions.combo_step1.clear()
@@ -67,8 +67,8 @@ def test_dimensions_radio_btn(qtbot):
     # dimensions 1-4
     assert histogram_parameters.dimensions.combo_step1.text() == "0.5"
     assert histogram_parameters.dimensions.combo_step2.text() == "0.2"
-    assert histogram_parameters.dimensions.combo_step3.text() == ""
-    assert histogram_parameters.dimensions.combo_step4.text() == ""
+    assert histogram_parameters.dimensions.combo_step3.text() == "0.02"
+    assert histogram_parameters.dimensions.combo_step4.text() == "2"
     assert histogram_parameters.dimensions.steps_valid_state() is True
 
     histogram_parameters.dimensions.combo_step1.clear()
@@ -87,9 +87,9 @@ def test_dimensions_radio_btn(qtbot):
 
     # dimensions 1-4
     assert histogram_parameters.dimensions.combo_step1.text() == "0.5"
-    assert histogram_parameters.dimensions.combo_step2.text() == ""
-    assert histogram_parameters.dimensions.combo_step3.text() == ""
-    assert histogram_parameters.dimensions.combo_step4.text() == ""
+    assert histogram_parameters.dimensions.combo_step2.text() == "0.2"
+    assert histogram_parameters.dimensions.combo_step3.text() == "0.02"
+    assert histogram_parameters.dimensions.combo_step4.text() == "2"
     assert histogram_parameters.dimensions.steps_valid_state() is True
 
 
@@ -354,37 +354,15 @@ def test_dimensions_dropdown_uniqueness(qtbot):
     qtbot.keyClicks(histogram_parameters.dimensions.combo_dim3, combo_dimensions[3])
 
     # dimensions 1-4
-    assert histogram_parameters.dimensions.combo_dim1.currentText() != combo_dimensions[3]
-    assert histogram_parameters.dimensions.combo_dim2.currentText() != combo_dimensions[3]
-    assert histogram_parameters.dimensions.combo_dim3.currentText() == combo_dimensions[3]
-    assert histogram_parameters.dimensions.combo_dim4.currentText() != combo_dimensions[3]
+    print(histogram_parameters.dimensions.combo_dim1.currentText())
+    print(histogram_parameters.dimensions.combo_dim2.currentText())
+    print(histogram_parameters.dimensions.combo_dim3.currentText())
+    print(histogram_parameters.dimensions.combo_dim4.currentText())
 
-    # assign 1 = [2]
-    qtbot.keyClicks(histogram_parameters.dimensions.combo_dim1, combo_dimensions[2])
-
-    # dimensions 1-4
-    assert histogram_parameters.dimensions.combo_dim1.currentText() == combo_dimensions[2]
-    assert histogram_parameters.dimensions.combo_dim2.currentText() != combo_dimensions[2]
-    assert histogram_parameters.dimensions.combo_dim3.currentText() != combo_dimensions[2]
-    assert histogram_parameters.dimensions.combo_dim4.currentText() != combo_dimensions[2]
-
-    # assign 4 = [1]
-    qtbot.keyClicks(histogram_parameters.dimensions.combo_dim4, combo_dimensions[1])
-
-    # dimensions 1-4
-    assert histogram_parameters.dimensions.combo_dim1.currentText() != combo_dimensions[1]
-    assert histogram_parameters.dimensions.combo_dim2.currentText() != combo_dimensions[1]
-    assert histogram_parameters.dimensions.combo_dim3.currentText() != combo_dimensions[1]
-    assert histogram_parameters.dimensions.combo_dim4.currentText() == combo_dimensions[1]
-
-    # assign 2 = [0]
-    qtbot.keyClicks(histogram_parameters.dimensions.combo_dim2, combo_dimensions[0])
-
-    # dimensions 1-4
-    assert histogram_parameters.dimensions.combo_dim1.currentText() != combo_dimensions[0]
-    assert histogram_parameters.dimensions.combo_dim2.currentText() == combo_dimensions[0]
-    assert histogram_parameters.dimensions.combo_dim3.currentText() != combo_dimensions[0]
-    assert histogram_parameters.dimensions.combo_dim4.currentText() != combo_dimensions[0]
+    assert histogram_parameters.dimensions.combo_dim1.currentText() == "[H,0,0]"
+    assert histogram_parameters.dimensions.combo_dim2.currentText() == "[0,K,0]"
+    assert histogram_parameters.dimensions.combo_dim3.currentText() == "DeltaE"
+    assert histogram_parameters.dimensions.combo_dim4.currentText() == "[0,0,L]"
 
 
 def test_dimensions_update_on_projection_edit(qtbot):


### PR DESCRIPTION
Description
---------------

This PR introduces the following changes:

- when swapping dimension in the parameter table, the corresponding min/max/step is also swapped
- step value is retain even if it is not visible
- adjust the config file parser (for `MakeSlice`) to accommodate the recent change


To Test
----------
- Clone the repo and shiver
- Input some values in the parameter table and start swapping the dimensions
  - The min/max/step value should also be auto swapped
- Perform a data reduction with `MakeSlice` and make sure the history is using correct parameters.  


> IBM item: [957](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=957)