### PR TITLE
Populate histogram UI from MakeSlice algorithm history

### DIFF
--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -163,6 +163,31 @@ class HistogramModel:
 
         self.algorithms_observers.remove(obs)
 
+    def get_make_slice_history(self, name) -> dict:
+        """Get the history of the last applied MakeSlice algorithm.
+
+        Parameters
+        ----------
+        name : str
+            The name of the histogram workspace for history retrieval
+
+        Returns
+        -------
+        dict
+            A dictionary of the history of the make slice algorithm
+        """
+        history_dict = {}
+        if mtd.doesExist(name):
+            histogram_ws = mtd[name]
+            alg_history = histogram_ws.getHistory().getAlgorithmHistories()
+            # look for the last make slice algorithm used
+            for alg in reversed(alg_history):
+                if alg.name() == "MakeSlice":
+                    for property in alg.getProperties():
+                        history_dict[property.name()] = property.value()
+                    break
+        return history_dict
+
 
 class MakeSliceObserver(AlgorithmObserver):
     """Object to handle the execution of MakeSlice algorithms"""

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -186,6 +186,17 @@ class HistogramModel:
                     for property in alg.getProperties():
                         history_dict[property.name()] = property.value()
                     break
+            # Quick sanity check to make sure the workspaces are still in memory
+            # If output workspace no longer in memory, replace with ""
+            # - input workspace
+            if not mtd.doesExist(history_dict.get("InputWorkspace", "")):
+                history_dict["InputWorkspace"] = ""
+            # - background workspace
+            if not mtd.doesExist(history_dict.get("BackgroundWorkspace", "")):
+                history_dict["BackgroundWorkspace"] = ""
+            # - normalization workspace
+            if not mtd.doesExist(history_dict.get("NormalizationWorkspace", "")):
+                history_dict["NormalizationWorkspace"] = ""
         return history_dict
 
 

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -183,8 +183,8 @@ class HistogramModel:
             # look for the last make slice algorithm used
             for alg in reversed(alg_history):
                 if alg.name() == "MakeSlice":
-                    for property in alg.getProperties():
-                        history_dict[property.name()] = property.value()
+                    for prop in alg.getProperties():
+                        history_dict[prop.name()] = prop.value()
                     break
             # Quick sanity check to make sure the workspaces are still in memory
             # If output workspace no longer in memory, replace with ""

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -193,6 +193,11 @@ class HistogramPresenter:
         if history_dict == {}:
             return
 
+        # reset mde workspaces
+        self.view.input_workspaces.mde_workspaces.reset()
+        # rest norm workspaces
+        self.view.input_workspaces.norm_workspaces.reset()
+
         # step 1: try to set the data workspace if it exists
         if history_dict["InputWorkspace"] != "":
             self.view.input_workspaces.mde_workspaces.set_data(history_dict["InputWorkspace"])

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -27,6 +27,9 @@ class HistogramPresenter:
         for name, ws_type, frame in self.model.get_all_valid_workspaces():
             self.view.add_ws(name, ws_type, frame)
 
+        # connect for populating UI when a histogram workspace is selected
+        self.view.histogram_workspaces.histogram_selected.connect(self.populate_ui_from_selected_histogram)
+
     def load_file(self, file_type, filename):
         """Call model to load the filename from the UI file dialog"""
         self.model.load(filename, file_type)
@@ -179,3 +182,7 @@ class HistogramPresenter:
             self.error_message("Please check the histogram parameters.")
             return False
         return True
+
+    def populate_ui_from_selected_histogram(self, name):
+        """Populate the UI from the selected histogram"""
+        print(f"Selected {name}")

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -207,3 +207,4 @@ class HistogramPresenter:
 
         # step 4: populate the histogram parameters widget based on given
         #         dictionary
+        self.view.histogram_parameters.populate_histogram_parameters(history_dict)

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -28,7 +28,7 @@ class HistogramPresenter:
             self.view.add_ws(name, ws_type, frame)
 
         # connect for populating UI when a histogram workspace is selected
-        self.view.histogram_workspaces.histogram_selected.connect(self.populate_ui_from_selected_histogram)
+        self.view.histogram_workspaces.histogram_selected_signal.connect(self.populate_ui_from_selected_histogram)
 
     def load_file(self, file_type, filename):
         """Call model to load the filename from the UI file dialog"""
@@ -185,4 +185,15 @@ class HistogramPresenter:
 
     def populate_ui_from_selected_histogram(self, name):
         """Populate the UI from the selected histogram"""
-        print(f"Selected {name}")
+        # step 0: ask model to get the history of MakeSlice from selected
+        #         workspace as a dictionary
+        history_dict = self.model.get_make_slice_history(name)
+
+        # step 1: try to set the data workspace if it exists
+
+        # step 2: try to set the background workspace if it exists
+
+        # step 3: try to select the normalization workspace if it exists
+
+        # step 4: populate the histogram parameters widget based on given
+        #         dictionary

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -165,9 +165,9 @@ class HistogramPresenter:
         # get the parameters from the view
         config.update(self.view.histogram_parameters.gather_histogram_parameters())
 
-        # use the name to generate the output workspace name
-        if config["Name"]:
-            config["OutputWorkspace"] = config["Name"].replace(" ", "_")
+        output_name = config.get("Name", None)
+        if output_name:
+            config["OutputWorkspace"] = output_name.replace(" ", "_")
         else:
             config["OutputWorkspace"] = "output_ws"
 
@@ -194,9 +194,9 @@ class HistogramPresenter:
             return
 
         # reset mde workspaces
-        self.view.input_workspaces.mde_workspaces.reset()
-        # rest norm workspaces
-        self.view.input_workspaces.norm_workspaces.reset()
+        self.view.input_workspaces.mde_workspaces.unset_all()
+        # reset norm workspaces
+        self.view.input_workspaces.norm_workspaces.deselect_all()
 
         # step 1: try to set the data workspace if it exists
         if history_dict["InputWorkspace"] != "":

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -189,11 +189,21 @@ class HistogramPresenter:
         #         workspace as a dictionary
         history_dict = self.model.get_make_slice_history(name)
 
+        # step 0: if nothing, skip
+        if history_dict == {}:
+            return
+
         # step 1: try to set the data workspace if it exists
+        if history_dict["InputWorkspace"] != "":
+            self.view.input_workspaces.mde_workspaces.set_data(history_dict["InputWorkspace"])
 
         # step 2: try to set the background workspace if it exists
+        if history_dict["BackgroundWorkspace"] != "":
+            self.view.input_workspaces.mde_workspaces.set_background(history_dict["BackgroundWorkspace"])
 
         # step 3: try to select the normalization workspace if it exists
+        if history_dict["NormalizationWorkspace"] != "":
+            self.view.input_workspaces.norm_workspaces.set_selected(history_dict["NormalizationWorkspace"])
 
         # step 4: populate the histogram parameters widget based on given
         #         dictionary

--- a/src/shiver/views/histogram_parameters.py
+++ b/src/shiver/views/histogram_parameters.py
@@ -298,6 +298,79 @@ class HistogramParameter(QGroupBox):
 
         return parameters
 
+    def populate_histogram_parameters(self, parameters: dict):
+        """Populates the histogram parameters from given dictionary."""
+        # set name
+        self.name.setText(parameters["OutputWorkspace"])
+
+        # populate the projection section
+        self.projection_u.setText(parameters["QDimension0"])
+        self.projection_v.setText(parameters["QDimension1"])
+        self.projection_w.setText(parameters["QDimension2"])
+
+        # populate the dimensions section
+        # step 0: build the search dictionary
+        search_dict = {
+            "QDimension0": self.projection_to_hkl(self.projection_u.text()),
+            "QDimension1": self.projection_to_hkl(self.projection_v.text()),
+            "QDimension2": self.projection_to_hkl(self.projection_w.text()),
+            "DeltaE": "DeltaE",
+        }
+        dim_names = [search_dict[parameters[f"Dimension{i}Name"]] for i in range(4)]
+        dim_bins = [parameters[f"Dimension{i}Binning"] for i in range(4)]
+        # sort both dim_bins and dim_names based on dim_bins
+        dim_bins, dim_names = zip(*sorted(zip(dim_bins, dim_names), key=lambda x: x[0], reverse=True))
+        # update all dimension combo boxes
+        self.dimensions.combo_dimensions = dim_names
+        self.dimensions.update_combo()
+        # update bin parameters
+        for i, bin_val in enumerate(dim_bins):
+            combo_min = self.combo_minx[i]
+            combo_max = self.combo_maxx[i]
+            combo_step = self.combo_stepx[i]
+            if bin_val == "":
+                # total integration
+                combo_min.setText("")
+                combo_max.setText("")
+                combo_step.setText("")
+            elif bin_val.count(",") == 0:
+                # total integration with step
+                combo_min.setText("")
+                combo_max.setText("")
+                combo_step.setText(bin_val)
+            elif bin_val.count(",") == 1:
+                # integration between start and stop
+                combo_min.setText(bin_val.split(",")[0])
+                combo_max.setText(bin_val.split(",")[1])
+                combo_step.setText("")
+            elif bin_val.count(",") == 2:
+                # integration between start and stop with step
+                combo_min.setText(bin_val.split(",")[0])
+                combo_max.setText(bin_val.split(",")[2])
+                combo_step.setText(bin_val.split(",")[1])
+            else:
+                # this should never happen
+                raise ValueError("Invalid binning parameters")
+        # step 1: figure out the cut dimension based on the binning parameters
+        # NOTE: click the toggle after enter the data will make sure the cell
+        #       background color is correct
+        cut_dim = [parameters[f"Dimension{i}Binning"] for i in range(4)].count("")
+        if cut_dim == 0:
+            self.cut_4d.setChecked(True)
+        elif cut_dim == 1:
+            self.cut_3d.setChecked(True)
+        elif cut_dim == 2:
+            self.cut_2d.setChecked(True)
+        elif cut_dim == 3:
+            self.cut_1d.setChecked(True)
+        else:
+            # this should never happen
+            raise ValueError("Invalid cut dimension")
+
+        # populate the symmetry section
+        self.symmetry_operations.setText(parameters["SymmetryOperations"])
+        self.smoothing.setValue(float(parameters["Smoothing"]))
+
     def connect_histogram_submit(self, callback):
         """callback for the histogram submit button"""
         self.histogram_callback = callback

--- a/src/shiver/views/histogram_parameters.py
+++ b/src/shiver/views/histogram_parameters.py
@@ -321,7 +321,7 @@ class HistogramParameter(QGroupBox):
         # sort both dim_bins and dim_names based on dim_bins
         dim_bins, dim_names = zip(*sorted(zip(dim_bins, dim_names), key=lambda x: x[0], reverse=True))
         # update all dimension combo boxes
-        self.dimensions.combo_dimensions = dim_names
+        self.dimensions.combo_dimensions = list(dim_names)
         self.dimensions.update_combo()
         # update bin parameters
         for i, bin_val in enumerate(dim_bins):

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -268,7 +268,7 @@ class MDEList(ADSList):
 class HistogramWorkspaces(QGroupBox):
     """Histogram workspaces widget"""
 
-    histogram_selected = Signal(str)
+    histogram_selected_signal = Signal(str)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -295,7 +295,7 @@ class HistogramWorkspaces(QGroupBox):
 
     def on_item_clicked(self, item):
         """method to emit a signal when a workspace is selected"""
-        self.histogram_selected.emit(item.text())
+        self.histogram_selected_signal.emit(item.text())
 
 
 def get_icon(name: str) -> QIcon:

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -116,7 +116,7 @@ class NormList(ADSList):
             self.rename_workspace_callback(name, dialog.textValue())  # pylint: disable=not-callable
 
     def delete_ws(self, name):
-        """mothod to delete the currently selected workspace"""
+        """method to delete the currently selected workspace"""
         if self.delete_workspace_callback:
             self.delete_workspace_callback(name)  # pylint: disable=not-callable
 
@@ -130,6 +130,11 @@ class NormList(ADSList):
         """
         item = self.findItems(name, Qt.MatchExactly)[0]
         self.setCurrentItem(item)
+
+    def deselect_all(self):
+        """reset the list"""
+        for item in self.selectedItems():
+            item.setSelected(False)
 
 
 class MDEList(ADSList):
@@ -275,7 +280,7 @@ class MDEList(ADSList):
         """return the workspace name set as background (optional, may be None)"""
         return self._background
 
-    def reset(self):
+    def unset_all(self):
         """reset the list"""
         # NOTE: DO NOT change the order, this is the correct logic to unset
         #       the data and background
@@ -317,11 +322,6 @@ class HistogramWorkspaces(QGroupBox):
     def on_item_clicked(self, item):
         """method to emit a signal when a workspace is selected"""
         self.histogram_selected_signal.emit(item.text())
-
-    def reset(self):
-        """reset the list"""
-        for item in self.histogram_workspaces.selectedItems():
-            item.setSelected(False)
 
 
 def get_icon(name: str) -> QIcon:

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -12,7 +12,7 @@ from qtpy.QtWidgets import (
     QInputDialog,
     QAbstractItemView,
 )
-from qtpy.QtCore import Qt, QSize
+from qtpy.QtCore import Qt, QSize, Signal
 from qtpy.QtGui import QIcon, QPixmap
 
 Frame = Enum("Frame", {"None": 1000, "QSample": 1001, "QLab": 1002, "HKL": 1003})
@@ -268,6 +268,8 @@ class MDEList(ADSList):
 class HistogramWorkspaces(QGroupBox):
     """Histogram workspaces widget"""
 
+    histogram_selected = Signal(str)
+
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setTitle("Histogram data in memory")
@@ -276,6 +278,8 @@ class HistogramWorkspaces(QGroupBox):
         layout = QVBoxLayout()
         layout.addWidget(self.histogram_workspaces)
         self.setLayout(layout)
+
+        self.histogram_workspaces.itemClicked.connect(self.on_item_clicked)
 
     def add_ws(self, name, ws_type, frame):
         """Adds a workspace to the list if it is of the correct type"""
@@ -288,6 +292,10 @@ class HistogramWorkspaces(QGroupBox):
     def clear_ws(self):
         """Clears all workspaces from the lists"""
         self.histogram_workspaces.clear()
+
+    def on_item_clicked(self, item):
+        """method to emit a signal when a workspace is selected"""
+        self.histogram_selected.emit(item.text())
 
 
 def get_icon(name: str) -> QIcon:

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -275,6 +275,16 @@ class MDEList(ADSList):
         """return the workspace name set as background (optional, may be None)"""
         return self._background
 
+    def reset(self):
+        """reset the list"""
+        # NOTE: DO NOT change the order, this is the correct logic to unset
+        #       the data and background
+        if self.data is not None:
+            self.set_background(self.data)
+
+        if self.background is not None:
+            self.unset_background(self.background)
+
 
 class HistogramWorkspaces(QGroupBox):
     """Histogram workspaces widget"""
@@ -307,6 +317,11 @@ class HistogramWorkspaces(QGroupBox):
     def on_item_clicked(self, item):
         """method to emit a signal when a workspace is selected"""
         self.histogram_selected_signal.emit(item.text())
+
+    def reset(self):
+        """reset the list"""
+        for item in self.histogram_workspaces.selectedItems():
+            item.setSelected(False)
 
 
 def get_icon(name: str) -> QIcon:

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -104,7 +104,7 @@ class NormList(ADSList):
         menu.setParent(None)  # Allow this QMenu instance to be cleaned up
 
     def rename_ws(self, name):
-        """methed to rename the currently selected workspace"""
+        """method to rename the currently selected workspace"""
         dialog = QInputDialog(self)
         dialog.setLabelText(f"Rename {name} to:")
         dialog.setTextValue(name)
@@ -116,9 +116,20 @@ class NormList(ADSList):
             self.rename_workspace_callback(name, dialog.textValue())  # pylint: disable=not-callable
 
     def delete_ws(self, name):
-        """methed to delete the currently selected workspace"""
+        """mothod to delete the currently selected workspace"""
         if self.delete_workspace_callback:
             self.delete_workspace_callback(name)  # pylint: disable=not-callable
+
+    def set_selected(self, name):
+        """method to set the selected workspace as selected
+
+        Parameters
+        ----------
+        name : str
+            Name of the workspace to select
+        """
+        item = self.findItems(name, Qt.MatchExactly)[0]
+        self.setCurrentItem(item)
 
 
 class MDEList(ADSList):

--- a/tests/models/test_gather_history.py
+++ b/tests/models/test_gather_history.py
@@ -1,0 +1,67 @@
+"""Test for histogram model."""
+import os
+import pytest
+from shiver.models.histogram import HistogramModel
+from mantid.simpleapi import (  # pylint: disable=no-name-in-module
+    LoadMD,
+    MakeSlice,
+)
+
+
+def test_get_make_slice_history():
+    model = HistogramModel()
+
+    # load mde workspace
+    LoadMD(
+        Filename=os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "../data/mde/merged_mde_MnO_25meV_5K_unpol_178921-178926.nxs"
+        ),
+        OutputWorkspace="data",
+    )
+    # call make slice
+    MakeSlice(
+        InputWorkspace="data",
+        BackgroundWorkspace=None,
+        NormalizationWorkspace=None,
+        QDimension0="0,0,1",
+        QDimension1="1,1,0",
+        QDimension2="-1,1,0",
+        Dimension0Name="QDimension1",
+        Dimension0Binning="0.35,0.025,0.65",
+        Dimension1Name="QDimension0",
+        Dimension1Binning="0.45,0.55",
+        Dimension2Name="QDimension2",
+        Dimension2Binning="-0.2,0.2",
+        Dimension3Name="DeltaE",
+        Dimension3Binning="-0.5,0.5",
+        SymmetryOperations=None,
+        Smoothing=1,
+        OutputWorkspace="line",
+    )
+    # gather history
+    history = model.get_make_slice_history("line")
+
+    # check
+    assert history == {
+        "InputWorkspace": "data",
+        "BackgroundWorkspace": "",
+        "NormalizationWorkspace": "",
+        "QDimension0": "0,0,1",
+        "QDimension1": "1,1,0",
+        "QDimension2": "-1,1,0",
+        "Dimension0Name": "QDimension1",
+        "Dimension0Binning": "0.35,0.025,0.65",
+        "Dimension1Name": "QDimension0",
+        "Dimension1Binning": "0.45,0.55",
+        "Dimension2Name": "QDimension2",
+        "Dimension2Binning": "-0.2,0.2",
+        "Dimension3Name": "DeltaE",
+        "Dimension3Binning": "-0.5,0.5",
+        "SymmetryOperations": "",
+        "Smoothing": "1",  # everything is converted to string in history
+        "OutputWorkspace": "line",
+    }
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/models/test_gather_history.py
+++ b/tests/models/test_gather_history.py
@@ -1,14 +1,15 @@
 """Test for histogram model."""
 import os
 import pytest
-from shiver.models.histogram import HistogramModel
 from mantid.simpleapi import (  # pylint: disable=no-name-in-module
     LoadMD,
     MakeSlice,
 )
+from shiver.models.histogram import HistogramModel
 
 
 def test_get_make_slice_history():
+    """Test get_make_slice_history method."""
     model = HistogramModel()
 
     # load mde workspace

--- a/tests/views/test_histogram.py
+++ b/tests/views/test_histogram.py
@@ -211,5 +211,67 @@ def test_make_histogram_button(shiver_app, qtbot):
     assert histogram_workspaces.item(0).text() == "output"
 
 
+def test_populate_ui_from_history_dict(shiver_app):
+    """Test the populate ui from history dict method."""
+    shiver = shiver_app
+    histogram_presenter = shiver.main_window.histogram_presenter
+
+    # load mde workspace
+    LoadMD(
+        Filename=os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "../data/mde/merged_mde_MnO_25meV_5K_unpol_178921-178926.nxs"
+        ),
+        OutputWorkspace="data",
+    )
+    # call make slice
+    MakeSlice(
+        InputWorkspace="data",
+        BackgroundWorkspace=None,
+        NormalizationWorkspace=None,
+        QDimension0="0,0,1",
+        QDimension1="1,1,0",
+        QDimension2="-1,1,0",
+        Dimension0Name="QDimension1",
+        Dimension0Binning="",
+        Dimension1Name="QDimension0",
+        Dimension1Binning="",
+        Dimension2Name="QDimension2",
+        Dimension2Binning="",
+        Dimension3Name="DeltaE",
+        Dimension3Binning="1",
+        SymmetryOperations=None,
+        Smoothing=1,
+        OutputWorkspace="line",
+    )
+
+    # populate the ui
+    histogram_presenter.populate_ui_from_selected_histogram("line")
+
+    # gather the config dict from current ui
+    config_dict = histogram_presenter.build_config_for_make_slice()
+
+    # verify
+    ref_dict = {
+        "InputWorkspace": "data",
+        "Name": "line",
+        "QDimension0": "0,0,1",
+        "QDimension1": "1,1,0",
+        "QDimension2": "-1,1,0",
+        "Dimension0Name": "DeltaE",
+        "Dimension0Binning": "1",
+        "Dimension1Name": "QDimension1",
+        "Dimension1Binning": "",
+        "Dimension2Name": "QDimension0",
+        "Dimension2Binning": "",
+        "Dimension3Name": "QDimension2",
+        "Dimension3Binning": "",
+        "SymmetryOperations": "",
+        "Smoothing": "1.00",
+        "OutputWorkspace": "line",
+    }
+
+    assert config_dict == ref_dict
+
+
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
This PR introduces the following changes:

- If a histogram workspace is generated with MakeSlice and present in the MDH column (right most), clicking on the name of the workspace will auto populate the histogram UI based on the history information from the MakeSlice algorithm.

To Test
---------

- Clone the feature branch and setup shiver as instructed in Readme
- Load the test MDE data and rename it to test1, test2
- Load the normalization data and rename it to norm1, norm2
![image](https://user-images.githubusercontent.com/5064852/231258053-8f3fc1e8-71c7-4461-8b72-645ee0d77c9a.png)
- Use the following settings to generate `Plot_1`
![image](https://user-images.githubusercontent.com/5064852/231258305-90c66a91-ba3a-41f8-a18d-4cfbc5c7a546.png)
- Use the following settings to generate `Plot_2`
![image](https://user-images.githubusercontent.com/5064852/231258474-f822239e-e80e-44f6-946f-0f5267cbe037.png)
- Now clicking back and forth between `Plot_1` and `Plot_2` should auto update the histogram UI with the numbers used to generate these workspace

> IBM item: [story596](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=596)