### PR TITLE
Remove workspace before new one created

### DIFF
--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -145,6 +145,11 @@ class HistogramModel:
 
     def do_make_slice(self, config: dict):
         """Method to take filename and workspace type and load with correct algorithm"""
+
+        # remove the OutputWorkspace first if it exists
+        if config.get("OutputWorkspace") and mtd.doesExist(config["OutputWorkspace"]):
+            self.delete(config["OutputWorkspace"])
+
         alg = AlgorithmManager.create("MakeSlice")
         alg_obs = MakeSliceObserver(parent=self)
         self.algorithms_observers.add(alg_obs)


### PR DESCRIPTION
This is to address an issue with plotting when the workspace is replaced with one that has different dimensionality

Fixes [1154](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=1154)