### PR TITLE
Add Raw Data selection widget

### DIFF
--- a/src/shiver/views/data.py
+++ b/src/shiver/views/data.py
@@ -52,7 +52,7 @@ class RawData(QGroupBox):
             self._update_file_list(self.path.text())
 
     def _browse(self):
-        directory = QFileDialog.getExistingDirectory(self)
+        directory = QFileDialog.getExistingDirectory(self, "Open Directory", self.directory)
         if directory:
             self._update_file_list(directory)
 

--- a/src/shiver/views/data.py
+++ b/src/shiver/views/data.py
@@ -29,7 +29,7 @@ class RawData(QGroupBox):
         self.browse.clicked.connect(self._browse)
 
         self.path = QLineEdit()
-        self.path.setReadOnly(True)
+        self.path.editingFinished.connect(self._path_edited)
 
         path_line = QWidget()
         path_layout = QHBoxLayout()
@@ -47,6 +47,10 @@ class RawData(QGroupBox):
         layout.addWidget(self.files)
         self.setLayout(layout)
 
+    def _path_edited(self):
+        if self.path.text() != self.directory:
+            self._update_file_list(self.path.text())
+
     def _browse(self):
         directory = QFileDialog.getExistingDirectory(self)
         if directory:
@@ -55,8 +59,8 @@ class RawData(QGroupBox):
     def _update_file_list(self, directory):
         self.directory = directory
         self.path.setText(directory)
-        filenames = glob.glob(os.path.join(directory, "*.nxs.h5"))
         self.files.clear()
+        filenames = glob.iglob(os.path.join(directory, "*.nxs.h5"))
         self.files.addItems([os.path.basename(f) for f in filenames])
 
     def get_selected(self):

--- a/src/shiver/views/data.py
+++ b/src/shiver/views/data.py
@@ -1,0 +1,84 @@
+"""PyQt widget for the raw data selection"""
+import os
+import glob
+
+from qtpy.QtWidgets import (
+    QWidget,
+    QGroupBox,
+    QFileDialog,
+    QPushButton,
+    QListWidget,
+    QLineEdit,
+    QLabel,
+    QVBoxLayout,
+    QHBoxLayout,
+    QAbstractItemView,
+)
+
+
+class RawData(QGroupBox):
+    """Raw data selection widget"""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setTitle("Raw data")
+
+        self.directory = None
+
+        self.browse = QPushButton("Browse")
+        self.browse.clicked.connect(self._browse)
+
+        self.path = QLineEdit()
+        self.path.setReadOnly(True)
+
+        path_line = QWidget()
+        path_layout = QHBoxLayout()
+        path_layout.addWidget(QLabel("Path"))
+        path_layout.addWidget(self.path)
+        path_layout.addWidget(self.browse)
+        path_line.setLayout(path_layout)
+
+        self.files = QListWidget()
+        self.files.setSelectionMode(QAbstractItemView.ExtendedSelection)
+        self.files.setSortingEnabled(True)
+
+        layout = QVBoxLayout()
+        layout.addWidget(path_line)
+        layout.addWidget(self.files)
+        self.setLayout(layout)
+
+    def _browse(self):
+        directory = QFileDialog.getExistingDirectory(self)
+        if directory:
+            self._update_file_list(directory)
+
+    def _update_file_list(self, directory):
+        self.directory = directory
+        self.path.setText(directory)
+        filenames = glob.glob(os.path.join(directory, "*.nxs.h5"))
+        self.files.clear()
+        self.files.addItems([os.path.basename(f) for f in filenames])
+
+    def get_selected(self):
+        """Return a list of the full path of the files selected"""
+        return [os.path.join(self.directory, f.text()) for f in self.files.selectedItems()]
+
+    def set_selected(self, filenames):
+        """Set the selected files
+
+        Expects a list of full file paths
+
+        This makes the assumption that all the files for in the same directory
+        """
+
+        if not filenames:
+            return
+
+        self._update_file_list(os.path.dirname(filenames[0]))
+
+        selected = {os.path.basename(f) for f in filenames}
+
+        for i in range(self.files.count()):
+            item = self.files.item(i)
+            if item.text() in selected:
+                item.setSelected(True)

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -6,6 +6,7 @@ from qtpy.QtWidgets import (
     QGroupBox,
     QPushButton,
 )
+from .data import RawData
 
 
 class Generate(QWidget):
@@ -15,20 +16,19 @@ class Generate(QWidget):
         super().__init__(parent)
 
         layout = QGridLayout()
+        layout.setRowMinimumHeight(1, 200)
+        layout.setRowMinimumHeight(2, 200)
+        layout.setColumnMinimumWidth(1, 400)
+        layout.setColumnMinimumWidth(2, 400)
+        layout.setColumnMinimumWidth(3, 400)
+
         layout.addWidget(RawData(self), 1, 1)
         layout.addWidget(Oncat(self), 2, 1)
         layout.addWidget(MDEType(self), 1, 2)
         layout.addWidget(ReductionParameters(self), 2, 2)
         layout.addWidget(Buttons(self), 1, 3, 2, 1)
+
         self.setLayout(layout)
-
-
-class RawData(QGroupBox):
-    """Raw data selection widget"""
-
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self.setTitle("Raw data")
 
 
 class Oncat(QGroupBox):

--- a/tests/views/test_raw_data.py
+++ b/tests/views/test_raw_data.py
@@ -1,0 +1,86 @@
+"""Test for the RawData widget"""
+
+import os
+from qtpy import QtCore, QtWidgets
+from shiver.views.data import RawData
+
+
+def test_raw_data_get_selection(qtbot):
+    """Test the browsing to path and selection of files"""
+
+    raw_data = RawData()
+    qtbot.addWidget(raw_data)
+    raw_data.show()
+
+    assert raw_data.files.count() == 0
+
+    directory = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../data/raw"))
+
+    # This is to handle modal dialogs
+    def handle_dialog():
+        # get a reference to the dialog and handle it here
+        dialog = raw_data.findChild(QtWidgets.QFileDialog)
+        # get a File Name field
+        line_edit = dialog.findChild(QtWidgets.QLineEdit)
+        # Type in file to load and press enter
+        qtbot.keyClicks(line_edit, directory)
+        qtbot.wait(100)
+        qtbot.keyClick(line_edit, QtCore.Qt.Key_Enter)
+
+    # click the Browse button
+    QtCore.QTimer.singleShot(100, handle_dialog)
+    raw_data.browse.click()
+
+    qtbot.wait(200)
+
+    assert raw_data.files.count() == 6
+    assert raw_data.get_selected() == []
+
+    # select 2nd and 4th items
+
+    qtbot.wait(100)
+
+    item = raw_data.files.item(1)
+    assert item.text() == "HYS_178922.nxs.h5"
+    qtbot.mouseClick(raw_data.files.viewport(), QtCore.Qt.LeftButton, pos=raw_data.files.visualItemRect(item).center())
+    qtbot.wait(100)
+
+    item = raw_data.files.item(3)
+    assert item.text() == "HYS_178924.nxs.h5"
+    qtbot.mouseClick(
+        raw_data.files.viewport(),
+        QtCore.Qt.LeftButton,
+        modifier=QtCore.Qt.KeyboardModifier.ControlModifier,
+        pos=raw_data.files.visualItemRect(item).center(),
+    )
+    qtbot.wait(100)
+
+    assert raw_data.get_selected() == [
+        os.path.join(directory, "HYS_178922.nxs.h5"),
+        os.path.join(directory, "HYS_178924.nxs.h5"),
+    ]
+
+
+def test_raw_data_set_selection(qtbot):
+    """Test setting the selected files"""
+    raw_data = RawData()
+    qtbot.addWidget(raw_data)
+    raw_data.show()
+
+    assert raw_data.files.count() == 0
+
+    directory = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../data/raw"))
+    files = ("HYS_178922.nxs.h5", "HYS_178923.nxs.h5", "HYS_178926.nxs.h5")
+    filenames = [os.path.join(directory, f) for f in files]
+
+    raw_data.set_selected(filenames)
+
+    qtbot.wait(100)
+
+    assert raw_data.files.count() == 6
+    selected = raw_data.files.selectedItems()
+    assert len(selected) == 3
+    for item in selected:
+        assert item.text() in files
+
+    assert raw_data.get_selected() == filenames

--- a/tests/views/test_raw_data.py
+++ b/tests/views/test_raw_data.py
@@ -61,6 +61,35 @@ def test_raw_data_get_selection(qtbot):
     ]
 
 
+def test_raw_data_editing_path(qtbot):
+    """Test the ability to edit the path directly"""
+
+    raw_data = RawData()
+    qtbot.addWidget(raw_data)
+    raw_data.show()
+
+    assert raw_data.files.count() == 0
+
+    directory = os.path.realpath(os.path.join(os.path.dirname(os.path.abspath(__file__)), "../data/raw"))
+
+    qtbot.keyClicks(raw_data.path, directory)
+    qtbot.keyClick(raw_data.path, QtCore.Qt.Key_Enter)
+
+    qtbot.wait(100)
+
+    assert raw_data.files.count() == 6
+    assert raw_data.get_selected() == []
+
+    # Add non-existing path, make sure list is empty
+    qtbot.keyClicks(raw_data.path, "/does/not/exist")
+    qtbot.keyClick(raw_data.path, QtCore.Qt.Key_Enter)
+
+    qtbot.wait(100)
+
+    assert raw_data.files.count() == 0
+    assert raw_data.get_selected() == []
+
+
 def test_raw_data_set_selection(qtbot):
     """Test setting the selected files"""
     raw_data = RawData()


### PR DESCRIPTION
[901](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=901)

You should be able to browse to a directory and only files with `.nxs.h5` extension will be shown in the list view. You should be able to select multiple files.

![raw_data_selection](https://user-images.githubusercontent.com/5595210/231806756-8c569bf6-f090-4d71-b93b-d568c877d675.png)

