### PR TITLE
Implement load dataset function (Phase 1)

### DIFF
--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -1,4 +1,5 @@
 """Model for the Histogram tab"""
+import time
 import os.path
 from typing import Tuple
 
@@ -108,7 +109,7 @@ class HistogramModel:
 
         # wait until all the workspaces are loaded
         while not all(mtd.doesExist(ws) for ws in (ws_data, ws_background, ws_norm) if ws is not None):
-            pass
+            time.sleep(0.1)
 
         return ws_data, ws_background, ws_norm
 

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -1,5 +1,6 @@
 """Model for the Histogram tab"""
 import os.path
+from typing import Tuple
 
 # pylint: disable=no-name-in-module
 from mantid.api import AlgorithmManager, AlgorithmObserver, AnalysisDataServiceObserver
@@ -53,6 +54,64 @@ class HistogramModel:
             logger.error(str(err))
             if self.error_callback:
                 self.error_callback(str(err))
+
+    def load_dataset(self, dataset: dict) -> Tuple[str, str, str]:
+        """Perform dataset loading with given parameters dictionary.
+
+        Parameters
+        ----------
+        dataset : dict
+            Dictionary of parameters for loading the dataset.
+
+        Returns
+        -------
+        Tuple[str, str, str]
+            Tuple of workspace names for data, background and normalization.
+        """
+        ws_data, ws_background, ws_norm = None, None, None
+        # Data & Background
+        if dataset["MdeName"] is not None:
+            if not mtd.doesExist(dataset["MdeName"]):
+                mde_name = dataset["MdeName"]
+                mde_file = os.path.join(dataset["MdeFolder"], f"{mde_name}.nxs")
+                # check if file exists
+                if not os.path.isfile(mde_file):
+                    # call generate-MDE
+                    self.generate_mde()
+                    ws_data = None
+                else:
+                    self.load(mde_file, "mde")
+                    ws_data = dataset["MdeName"]
+
+        if dataset["BackgroundMdeName"] is not None:
+            if not mtd.doesExist(dataset["BackgroundMdeName"]):
+                mde_name = dataset["BackgroundMdeName"]
+                mde_file = os.path.join(dataset["MdeFolder"], f"{mde_name}.nxs")
+                # check if file exists
+                if not os.path.isfile(mde_file):
+                    # call generate-MDE
+                    self.generate_mde()
+                    ws_background = None
+                else:
+                    self.load(mde_file, "mde")
+                    ws_background = dataset["BackgroundMdeName"]
+
+        # Normalization
+        if dataset["NormalizationDataFile"] is not None:
+            norm_name = os.path.basename(dataset["NormalizationDataFile"]).split(".")[0]
+            if not mtd.doesExist(norm_name):
+                self.load(dataset["NormalizationDataFile"], "norm")
+            ws_norm = norm_name
+
+        # wait until all the workspaces are loaded
+        while not all(mtd.doesExist(ws) for ws in (ws_data, ws_background, ws_norm) if ws is not None):
+            pass
+
+        return ws_data, ws_background, ws_norm
+
+    def generate_mde(self) -> str:
+        """Generate MDE workspace from given parameters dictionary."""
+        logger.error("Not implemented yet.")
 
     def delete(self, ws_name):
         """Delete the workspace"""

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -56,7 +56,7 @@ class HistogramModel:
             if self.error_callback:
                 self.error_callback(str(err))
 
-    def load_dataset(self, dataset: dict) -> Tuple[str, str, str]:
+    def load_dataset(self, dataset: dict) -> Tuple[str, str, str]:  # pylint: disable=too-many-branches
         """Perform dataset loading with given parameters dictionary.
 
         Parameters
@@ -84,6 +84,8 @@ class HistogramModel:
                 else:
                     self.load(mde_file, "mde")
                     ws_data = mde_name
+            else:
+                ws_data = mde_name
 
         bg_name = dataset.get("BackgroundMdeName", None)
         if bg_name is not None:
@@ -98,6 +100,8 @@ class HistogramModel:
                 else:
                     self.load(mde_file, "mde")
                     ws_background = bg_name
+            else:
+                ws_background = bg_name
 
         # Normalization
         norm_data_file = dataset.get("NormalizationDataFile", None)

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -70,10 +70,11 @@ class HistogramModel:
         """
         ws_data, ws_background, ws_norm = None, None, None
         # Data & Background
-        if dataset["MdeName"] is not None:
-            if not mtd.doesExist(dataset["MdeName"]):
-                mde_name = dataset["MdeName"]
-                mde_file = os.path.join(dataset["MdeFolder"], f"{mde_name}.nxs")
+        mde_name = dataset.get("MdeName", None)
+        if mde_name is not None:
+            if not mtd.doesExist(mde_name):
+                mde_folder = dataset.get("MdeFolder", "")
+                mde_file = os.path.join(mde_folder, f"{mde_name}.nxs")
                 # check if file exists
                 if not os.path.isfile(mde_file):
                     # call generate-MDE
@@ -81,12 +82,13 @@ class HistogramModel:
                     ws_data = None
                 else:
                     self.load(mde_file, "mde")
-                    ws_data = dataset["MdeName"]
+                    ws_data = mde_name
 
-        if dataset["BackgroundMdeName"] is not None:
-            if not mtd.doesExist(dataset["BackgroundMdeName"]):
-                mde_name = dataset["BackgroundMdeName"]
-                mde_file = os.path.join(dataset["MdeFolder"], f"{mde_name}.nxs")
+        bg_name = dataset.get("BackgroundMdeName", None)
+        if bg_name is not None:
+            if not mtd.doesExist(bg_name):
+                mde_folder = dataset.get("MdeFolder", "")
+                mde_file = os.path.join(mde_folder, f"{bg_name}.nxs")
                 # check if file exists
                 if not os.path.isfile(mde_file):
                     # call generate-MDE
@@ -94,13 +96,14 @@ class HistogramModel:
                     ws_background = None
                 else:
                     self.load(mde_file, "mde")
-                    ws_background = dataset["BackgroundMdeName"]
+                    ws_background = bg_name
 
         # Normalization
-        if dataset["NormalizationDataFile"] is not None:
-            norm_name = os.path.basename(dataset["NormalizationDataFile"]).split(".")[0]
+        norm_data_file = dataset.get("NormalizationDataFile", None)
+        if norm_data_file is not None:
+            norm_name = os.path.basename(norm_data_file).split(".")[0]
             if not mtd.doesExist(norm_name):
-                self.load(dataset["NormalizationDataFile"], "norm")
+                self.load(norm_data_file, "norm")
             ws_norm = norm_name
 
         # wait until all the workspaces are loaded

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -15,6 +15,7 @@ class HistogramPresenter:
         self.view.histogram_parameters.connect_histogram_submit(self.handle_button)
         self.view.histogram_parameters.histogram_btn.clicked.connect(self.submit_histogram_to_make_slice)
 
+        self.view.buttons.connect_load_dataset(self.load_dataset)
         self.view.buttons.connect_load_file(self.load_file)
         self.view.connect_delete_workspace(self.delete_workspace)
         self.view.connect_rename_workspace(self.rename_workspace)
@@ -35,6 +36,23 @@ class HistogramPresenter:
     def load_file(self, file_type, filename):
         """Call model to load the filename from the UI file dialog"""
         self.model.load(filename, file_type)
+
+    def load_dataset(self, dataset: dict):
+        """Call model to perform dataset loading with the given parameters."""
+        data, background, norm = self.model.load_dataset(dataset)
+
+        # set the data in the view
+        if data:
+            self.view.set_data(data)
+        # set the background in the view
+        if background:
+            self.view.set_background(background)
+        # select the normalization in the view
+        if norm:
+            # NOTE: this is a bit of a hack to get around the fact that sometime the
+            #      normalization is not set in the view until the next event loop
+            while self.view.get_selected_normalization() != norm:
+                self.view.select_normalization(norm)
 
     @property
     def view(self):

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -41,6 +41,8 @@ class HistogramPresenter:
         """Call model to perform dataset loading with the given parameters."""
         data, background, norm = self.model.load_dataset(dataset)
 
+        self.view.unset_all()
+
         # set the data in the view
         if data:
             self.view.set_data(data)

--- a/src/shiver/views/histogram.py
+++ b/src/shiver/views/histogram.py
@@ -33,6 +33,8 @@ class Histogram(QWidget):
 
         self.error_message_signal.connect(self._show_error_message)
 
+        self.buttons.connect_error_msg(self.show_error_message)
+
     def show_error_message(self, msg):
         """Will show a error dialog with the given message
 

--- a/src/shiver/views/histogram.py
+++ b/src/shiver/views/histogram.py
@@ -98,3 +98,19 @@ class Histogram(QWidget):
         #       selected list of normalization workspaces
         selected_items = self.input_workspaces.norm_workspaces.selectedItems()
         return None if len(selected_items) == 0 else selected_items[0].text()
+
+    def set_data(self, data):
+        """Set the data workspace."""
+        self.input_workspaces.mde_workspaces.set_data(data)
+
+    def set_background(self, background):
+        """Set the background workspace."""
+        self.input_workspaces.mde_workspaces.set_background(background)
+
+    def select_normalization(self, normalization):
+        """Select the normalization workspace."""
+        self.input_workspaces.norm_workspaces.set_selected(normalization)
+
+    def get_selected_normalization(self):
+        """Return the selected normalization workspace."""
+        return self.input_workspaces.norm_workspaces.get_selected()

--- a/src/shiver/views/histogram.py
+++ b/src/shiver/views/histogram.py
@@ -116,3 +116,8 @@ class Histogram(QWidget):
     def get_selected_normalization(self):
         """Return the selected normalization workspace."""
         return self.input_workspaces.norm_workspaces.get_selected()
+
+    def unset_all(self):
+        """Unset all workspaces."""
+        self.input_workspaces.mde_workspaces.unset_all()
+        self.input_workspaces.norm_workspaces.deselect_all()

--- a/src/shiver/views/loading_buttons.py
+++ b/src/shiver/views/loading_buttons.py
@@ -118,10 +118,11 @@ class LoadingButtons(QWidget):
         spec.loader.exec_module(module)
         try:
             data_set_list = module.define_data_set()
-        except AttributeError as error:
+        except Exception as error:
             if self.error_msg_callback:
                 self.error_msg_callback(f"Error: {error}")
             return []
+
         return data_set_list
 
     def connect_load_file(self, callback):

--- a/src/shiver/views/loading_buttons.py
+++ b/src/shiver/views/loading_buttons.py
@@ -1,5 +1,6 @@
 """PyQt widget for the histogram tab"""
-import importlib, os
+import importlib
+import os
 from qtpy.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -56,7 +57,10 @@ class LoadingButtons(QWidget):
         """Load a dataset from a Python file."""
         # get the file name
         filename, _ = QFileDialog.getOpenFileName(
-            self, "Select the Python file defines the dataset", "", "Python file (*.py);;All files (*)",
+            self,
+            "Select the Python file defines the dataset",
+            "",
+            "Python file (*.py);;All files (*)",
         )
         if not filename:
             return
@@ -65,7 +69,7 @@ class LoadingButtons(QWidget):
         data_set_list = self.extract_dataset_list(filename)
 
         # pop up a dialog to ask the user to enter an integer to select a dataset
-        dataset_index, ok = QInputDialog.getInt(
+        dataset_index, success = QInputDialog.getInt(
             self,
             "Enter a dataset index)",  # title
             f"Index [0 - {len(data_set_list) - 1}]",  # label
@@ -73,11 +77,10 @@ class LoadingButtons(QWidget):
             0,  # min
             len(data_set_list) - 1,  # max
         )
-        if not ok:
+        if not success:
             return
 
         data_set = data_set_list[dataset_index]
-        print(data_set)
         # import the function from the file
         if self.load_dataset_callback:
             self.load_dataset_callback(data_set)

--- a/src/shiver/views/loading_buttons.py
+++ b/src/shiver/views/loading_buttons.py
@@ -108,15 +108,15 @@ class LoadingButtons(QWidget):
         data_set_list : list
             a list of data set.
         """
-        # import the function dynamically from given Python file
-        module_name = os.path.splitext(os.path.basename(filename))[0]
-        spec = importlib.util.spec_from_file_location(
-            module_name,
-            filename,
-        )
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
         try:
+            # import the function dynamically from given Python file
+            module_name = os.path.splitext(os.path.basename(filename))[0]
+            spec = importlib.util.spec_from_file_location(
+                module_name,
+                filename,
+            )
+            module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(module)
             data_set_list = module.define_data_set()
         except Exception as error:  # pylint: disable=broad-except
             if self.error_msg_callback:

--- a/src/shiver/views/loading_buttons.py
+++ b/src/shiver/views/loading_buttons.py
@@ -35,6 +35,7 @@ class LoadingButtons(QWidget):
 
         self.file_load_callback = None
         self.load_dataset_callback = None
+        self.error_msg_callback = None
 
         # disable generate dataset button (not implemented for phase 1)
         self.gen_dataset.setEnabled(False)
@@ -115,7 +116,12 @@ class LoadingButtons(QWidget):
         )
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
-        data_set_list = module.define_data_set()
+        try:
+            data_set_list = module.define_data_set()
+        except AttributeError as error:
+            if self.error_msg_callback:
+                self.error_msg_callback(f"Error: {error}")
+            return []
         return data_set_list
 
     def connect_load_file(self, callback):
@@ -131,3 +137,13 @@ class LoadingButtons(QWidget):
             the function to be called when a dataset is selected.
         """
         self.load_dataset_callback = callback
+
+    def connect_error_msg(self, callback):
+        """connect a function to the error message.
+
+        Parameters
+        ----------
+        callback : function
+            the function to be called when an error message is needed.
+        """
+        self.error_msg_callback = callback

--- a/src/shiver/views/loading_buttons.py
+++ b/src/shiver/views/loading_buttons.py
@@ -118,7 +118,7 @@ class LoadingButtons(QWidget):
         spec.loader.exec_module(module)
         try:
             data_set_list = module.define_data_set()
-        except Exception as error:
+        except Exception as error:  # pylint: disable=broad-except
             if self.error_msg_callback:
                 self.error_msg_callback(f"Error: {error}")
             return []

--- a/src/shiver/views/loading_buttons.py
+++ b/src/shiver/views/loading_buttons.py
@@ -31,6 +31,9 @@ class LoadingButtons(QWidget):
 
         self.file_load_callback = None
 
+        # disable generate dataset button (not implemented for phase 1)
+        self.gen_dataset.setEnabled(False)
+
     def _on_load_mde_click(self):
         filename, _ = QFileDialog.getOpenFileName(
             self, "Select one or more files to open", "", "NeXus file (*.nxs);;All files (*)"

--- a/src/shiver/views/loading_buttons.py
+++ b/src/shiver/views/loading_buttons.py
@@ -68,17 +68,26 @@ class LoadingButtons(QWidget):
         # import the function dynamically from given Python file
         data_set_list = self.extract_dataset_list(filename)
 
-        # pop up a dialog to ask the user to enter an integer to select a dataset
-        dataset_index, success = QInputDialog.getInt(
-            self,
-            "Enter a dataset index)",  # title
-            f"Index [0 - {len(data_set_list) - 1}]",  # label
-            0,  # default value
-            0,  # min
-            len(data_set_list) - 1,  # max
-        )
-        if not success:
+        if len(data_set_list) == 0:
             return
+
+        if len(data_set_list) == 1:
+            # no need to ask the user to select a dataset
+            dataset_index = 0
+        else:
+            # pop up a dialog to ask the user to enter an integer to select a dataset
+            # NOTE: pytest cannot find this widget as it is Qt's shortcut to create
+            #       a input dialog without making a whole new class.
+            dataset_index, success = QInputDialog.getInt(
+                self,
+                "Enter a dataset index)",  # title
+                f"Index [0 - {len(data_set_list) - 1}]",  # label
+                0,  # default value
+                0,  # min
+                len(data_set_list) - 1,  # max
+            )
+            if not success:
+                return
 
         data_set = data_set_list[dataset_index]
         # import the function from the file

--- a/src/shiver/views/loading_buttons.py
+++ b/src/shiver/views/loading_buttons.py
@@ -1,9 +1,11 @@
 """PyQt widget for the histogram tab"""
+import importlib, os
 from qtpy.QtWidgets import (
     QWidget,
     QVBoxLayout,
     QPushButton,
     QFileDialog,
+    QInputDialog,
 )
 
 
@@ -26,10 +28,12 @@ class LoadingButtons(QWidget):
         layout.addStretch()
         self.setLayout(layout)
 
+        self.load_dataset.clicked.connect(self._on_load_dataset_click)
         self.load_mde.clicked.connect(self._on_load_mde_click)
         self.load_norm.clicked.connect(self._on_load_norm_click)
 
         self.file_load_callback = None
+        self.load_dataset_callback = None
 
         # disable generate dataset button (not implemented for phase 1)
         self.gen_dataset.setEnabled(False)
@@ -48,6 +52,70 @@ class LoadingButtons(QWidget):
         if filename and self.file_load_callback:
             self.file_load_callback("norm", filename)
 
+    def _on_load_dataset_click(self):
+        """Load a dataset from a Python file."""
+        # get the file name
+        filename, _ = QFileDialog.getOpenFileName(
+            self, "Select the Python file defines the dataset", "", "Python file (*.py);;All files (*)",
+        )
+        if not filename:
+            return
+
+        # import the function dynamically from given Python file
+        data_set_list = self.extract_dataset_list(filename)
+
+        # pop up a dialog to ask the user to enter an integer to select a dataset
+        dataset_index, ok = QInputDialog.getInt(
+            self,
+            "Enter a dataset index)",  # title
+            f"Index [0 - {len(data_set_list) - 1}]",  # label
+            0,  # default value
+            0,  # min
+            len(data_set_list) - 1,  # max
+        )
+        if not ok:
+            return
+
+        data_set = data_set_list[dataset_index]
+        print(data_set)
+        # import the function from the file
+        if self.load_dataset_callback:
+            self.load_dataset_callback(data_set)
+
+    def extract_dataset_list(self, filename):
+        """extract the dataset list from the given file.
+
+        Parameters
+        ----------
+        filename : str
+            the file name of the Python file that defines the dataset.
+
+        Returns
+        -------
+        data_set_list : list
+            a list of data set.
+        """
+        # import the function dynamically from given Python file
+        module_name = os.path.splitext(os.path.basename(filename))[0]
+        spec = importlib.util.spec_from_file_location(
+            module_name,
+            filename,
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        data_set_list = module.define_data_set()
+        return data_set_list
+
     def connect_load_file(self, callback):
         """connect a function to the selection of a filename"""
         self.file_load_callback = callback
+
+    def connect_load_dataset(self, callback):
+        """connect a function to the selection of a dataset.
+
+        Parameters
+        ----------
+        callback : function
+            the function to be called when a dataset is selected.
+        """
+        self.load_dataset_callback = callback

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -134,13 +134,29 @@ class NormList(ADSList):
         name : str
             Name of the workspace to select
         """
-        item = self.findItems(name, Qt.MatchExactly)[0]
-        self.setCurrentItem(item)
+        # NOTE: norm list is in single selection mode, so we don't have to
+        #       explicitly deselect the other items
+        items = self.findItems(name, Qt.MatchExactly)
+        if items:
+            self.setCurrentItem(items[0])
 
     def deselect_all(self):
         """reset the list"""
         for item in self.selectedItems():
             item.setSelected(False)
+
+    def get_selected(self):
+        """method to get the selected workspace
+
+        Returns
+        -------
+        str
+            Name of the selected workspace
+        """
+        selected = self.selectedItems()
+        if selected:
+            return selected[0].text()
+        return None
 
 
 class MDEList(ADSList):

--- a/tests/data/define_data.py
+++ b/tests/data/define_data.py
@@ -3,7 +3,7 @@
 import os
 
 
-def define_data_set(**kwargs) -> list:
+def define_data_set(**kwargs) -> list:  # pylint: disable=unused-argument
     """Function serve as singleton for data set definition."""
     mde_folder = os.path.join(os.path.dirname(__file__), "mde")
     raw_data_folder = os.path.join(os.path.dirname(__file__), "raw")
@@ -13,9 +13,7 @@ def define_data_set(**kwargs) -> list:
     # data set 1
     # NOTE: using existing data for unit testing
     data_set = {
-        "Runs": range(
-            178921, 178927
-        ),  # List of runs, or list of lists of runs that are added together
+        "Runs": range(178921, 178927),  # List of runs, or list of lists of runs that are added together
         "BackgroundRuns": None,  # range(297325,297337)Options: None;list of runs that are added together
         "RawDataFolder": raw_data_folder,  # Options:raw_data_folder string
         "RawDataFolderBackground": None,  # Options:None (same as the raw data); bknd_raw_data_folder string
@@ -24,9 +22,7 @@ def define_data_set(**kwargs) -> list:
         "MdeName": "merged_mde_MnO_25meV_5K_unpol_178921-178926",  # Options:mde_name string
         "BackgroundMdeName": None,  # Options:None;bg_mde_name string
         "MaskingDataFile": None,  # Options:None;data_file_name
-        "NormalizationDataFile": os.path.join(
-            normalization_data_folder, "TiZr.nxs"
-        ),  # Options:None;data_file_name
+        "NormalizationDataFile": os.path.join(normalization_data_folder, "TiZr.nxs"),  # Options:None;data_file_name
         "SampleLogVariables": {
             "OmegaMotorName": None,
             "Temperature": 3.0,

--- a/tests/data/define_data.py
+++ b/tests/data/define_data.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+"""Define data demo for test."""
+import os
+
+
+def define_data_set(**kwargs) -> list:
+    """Function serve as singleton for data set definition."""
+    mde_folder = os.path.join(os.path.dirname(__file__), "mde")
+    raw_data_folder = os.path.join(os.path.dirname(__file__), "raw")
+    normalization_data_folder = os.path.join(os.path.dirname(__file__), "normalization")
+
+    data_set_list = []
+    # data set 1
+    # NOTE: using existing data for unit testing
+    data_set = {
+        "Runs": range(
+            178921, 178927
+        ),  # List of runs, or list of lists of runs that are added together
+        "BackgroundRuns": None,  # range(297325,297337)Options: None;list of runs that are added together
+        "RawDataFolder": raw_data_folder,  # Options:raw_data_folder string
+        "RawDataFolderBackground": None,  # Options:None (same as the raw data); bknd_raw_data_folder string
+        "BackgroundScaling": 1,  # Options: None (same as 1); scaling factor
+        "MdeFolder": mde_folder,  # Options:mde_folder string
+        "MdeName": "merged_mde_MnO_25meV_5K_unpol_178921-178926",  # Options:mde_name string
+        "BackgroundMdeName": None,  # Options:None;bg_mde_name string
+        "MaskingDataFile": None,  # Options:None;data_file_name
+        "NormalizationDataFile": os.path.join(
+            normalization_data_folder, "TiZr.nxs"
+        ),  # Options:None;data_file_name
+        "SampleLogVariables": {
+            "OmegaMotorName": None,
+            "Temperature": 3.0,
+            "MagneticField": 0.0,
+        },  # Options:None;LogVariableName;number
+        "USSetup": {
+            "a": 5.12484,
+            "b": 5.33161,
+            "c": 7.31103,
+            "alpha": 90,
+            "beta": 90,
+            "gamma": 90,
+            "u": "-0.0493617,4.27279,-4.37293",
+            "v": "-0.0706905,-3.18894,-5.85775",
+        },
+        # Data reduction options
+        "Ei": None,  # Options: None;Ei_somehow_determined
+        "T0": None,  # Options: None;T0_determined_from_mantid
+        "BadPulsesThreshold": None,  # Options: None;bg_pulses_threshold value
+        "TimeIndepBackgroundWindow": "Default",  # Options: None;'Default';[Tib_min,Tib_max]
+        "E_min": None,  # Options: None;Emin if None the value is -0.95*Ei
+        "E_max": None,  # Options: None;Emax if None the value is 0.95*Ei
+        "AdditionalDimensions": None,  # Options: None;list of triplets ("name", min, max)
+        # Polarized data options
+        "PolarizationState": None,  # Options:None;'SF_Px';'NSF_Px';'SF_Py';'NSF_Py';'SF_Pz';'NSF_Pz'
+        "FlippingRatio": None,  # Options:None;'14';'6.5+2.8*cos((omega+3.7)*pi/180),omega'
+        "PolarizingSupermirrorDeflectionAdjustment": None,  # Options:None;deflection_angle
+        "EfCorrectionFunction": None,  # Options:None;'HYSPEC_default_correction';Custom_Ef_Correction_Function_Name
+    }
+
+    data_set_list.append(data_set)
+
+    return data_set_list
+
+
+if __name__ == "__main__":
+    print("This is a module for data set definition.")

--- a/tests/models/test_load.py
+++ b/tests/models/test_load.py
@@ -1,5 +1,6 @@
 """Tests for the file loading part of the HistogramModel"""
 import time
+import os
 from mantid.simpleapi import (  # pylint: disable=no-name-in-module
     CreateMDWorkspace,
     SaveMD,
@@ -95,3 +96,35 @@ def test_bad_file(tmp_path):
         f"""Error loading {filename} as mde
 ERROR: Kernel::NexusHDF5Descriptor couldn't open hdf5 file {filename} with fapl"""
     )
+
+
+def test_load_dataset():
+    """test loading dataset from Python file"""
+    # We need to use the pre-generated test file
+    # as we need to load actual data
+    model = HistogramModel()
+
+    # make the dataset dict
+    mde_folder = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "data",
+        "mde",
+    )
+    norm_folder = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "data",
+        "normalization",
+    )
+    dataset_dict = {
+        "MdeName": "merged_mde_MnO_25meV_5K_unpol_178921-178926",
+        "MdeFolder": mde_folder,
+        "BackgroundMdeName": None,
+        "NormalizationDataFile": os.path.join(norm_folder, "TiZr.nxs"),
+    }
+
+    ws_data, ws_background, ws_norm = model.load_dataset(dataset_dict)
+    assert ws_data == "merged_mde_MnO_25meV_5K_unpol_178921-178926"
+    assert ws_background is None
+    assert ws_norm == "TiZr"

--- a/tests/views/test_histogram.py
+++ b/tests/views/test_histogram.py
@@ -273,5 +273,40 @@ def test_populate_ui_from_history_dict(shiver_app):
     assert config_dict == ref_dict
 
 
+def test_load_dataset_presenter(shiver_app):
+    """Test the load dataset presenter."""
+    shiver = shiver_app
+    histogram_presenter = shiver.main_window.histogram_presenter
+    histogram_view = shiver.main_window.histogram
+
+    # make the dataset dict
+    mde_folder = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "data",
+        "mde",
+    )
+    norm_folder = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "data",
+        "normalization",
+    )
+    dataset_dict = {
+        "MdeName": "merged_mde_MnO_25meV_5K_unpol_178921-178926",
+        "MdeFolder": mde_folder,
+        "BackgroundMdeName": None,
+        "NormalizationDataFile": os.path.join(norm_folder, "TiZr.nxs"),
+    }
+
+    # load the dataset
+    histogram_presenter.load_dataset(dataset_dict)
+
+    # verify
+    assert histogram_view.gather_workspace_data() == "merged_mde_MnO_25meV_5K_unpol_178921-178926"
+    assert histogram_view.gather_workspace_background() is None
+    assert histogram_view.get_selected_normalization() == "TiZr"
+
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/tests/views/test_loading_buttons.py
+++ b/tests/views/test_loading_buttons.py
@@ -53,3 +53,44 @@ def test_file_loading(qtbot, tmp_path):
 
     assert len(file_load_calls) == 2
     assert file_load_calls[-1] == ("mde", str(filename))
+
+
+def test_load_dataset_button(qtbot, tmp_path):
+    """Test for pressing the load dataset button and checking that the callback function is called"""
+    # create test data
+    filename = tmp_path / "test.py"
+    filename.write_text("def define_data_set(): return [{}]")
+
+    # start widget
+    buttons = LoadingButtons()
+    qtbot.addWidget(buttons)
+    buttons.show()
+
+    # load dataset callback
+    dataset_load_calls = []
+
+    def load_dataset_callback(filename):
+        dataset_load_calls.append(filename)
+
+    buttons.connect_load_dataset(load_dataset_callback)
+
+    # This is to handle modal dialogs
+    def handle_dialog(filename):
+        # get a reference to the dialog and handle it here
+        dialog = buttons.findChild(QtWidgets.QFileDialog)
+        # get a File Name field
+        line_edit = dialog.findChild(QtWidgets.QLineEdit)
+        # Type in file to load and press enter
+        qtbot.keyClicks(line_edit, filename)
+        qtbot.wait(100)
+        qtbot.keyClick(line_edit, QtCore.Qt.Key_Enter)
+
+    assert len(dataset_load_calls) == 0
+
+    # click on load dataset
+    QtCore.QTimer.singleShot(500, functools.partial(handle_dialog, str(filename)))
+    qtbot.mouseClick(buttons.load_dataset, QtCore.Qt.LeftButton)
+
+    qtbot.wait(100)
+
+    assert len(dataset_load_calls) == 1


### PR DESCRIPTION
This PR introduces the following changes:

- Implement functionality to allow batch loading dataset (data, background and normalization) defined from a Python file (dictionary)
- Add example Python file
- Add corresponding unit tests

To Test
---------

- Clone the feature branch and setup editable install as instructed in Readme.
- Use the load dataset button to load the data definition file from test folder
![image](https://user-images.githubusercontent.com/5064852/231815973-84aa0149-ce0f-462a-a249-5618894240f4.png)
  - since there is only one dataset defined, it will use it by default
  - if there are multiple ones, a pop up window will show up to allow selection
- The data and normalization should be set automatically after click okay
![image](https://user-images.githubusercontent.com/5064852/231816310-92917f80-facb-497a-bc76-2efc8811974f.png)


> IBM item: [Story592](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=592)