### PR TITLE
Add MDE type widget in generate tab

### DIFF
--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -5,6 +5,12 @@ from qtpy.QtWidgets import (
     QGridLayout,
     QGroupBox,
     QPushButton,
+    QLabel,
+    QLineEdit,
+    QSpacerItem,
+    QSizePolicy,
+    QButtonGroup,
+    QRadioButton,
 )
 from .data import RawData
 
@@ -45,6 +51,53 @@ class MDEType(QGroupBox):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.setTitle("MDE type")
+        self.layout = QGridLayout()
+
+        # mde name (label) and input
+        mde_name_label = QLabel("MDE name")
+        self.mde_name = QLineEdit("")
+        self.mde_name.setObjectName("mde_name")
+        self.layout.addWidget(mde_name_label, 0, 0)
+        self.layout.addWidget(self.mde_name, 0, 1)
+        self.layout.addItem(QSpacerItem(0, 0, QSizePolicy.Expanding, QSizePolicy.Minimum), 0, 2)
+
+        # output directory and browse button
+        output_dir_label = QLabel("Output Folder")
+        self.output_dir = QLineEdit("")
+        self.output_dir.setObjectName("output_dir")
+        browse_button = QPushButton("Browse")
+        browse_button.setObjectName("browse_button")
+        browse_button.setToolTip("Browse for output folder")
+        browse_button.setFixedWidth(100)
+        self.layout.addWidget(output_dir_label, 1, 0)
+        self.layout.addWidget(self.output_dir, 1, 1)
+        self.layout.addWidget(browse_button, 1, 2)
+
+        # add a small gap between the two sections
+        self.layout.addItem(QSpacerItem(0, 10, QSizePolicy.Minimum, QSizePolicy.Minimum), 2, 0)
+
+        # mde type (label) and radio button group
+        mde_type_label = QLabel("MDE type")
+        self.mde_type_data = QRadioButton("Data")
+        self.mde_type_data.setObjectName("mde_type_data")
+        self.mde_type_data.setChecked(True)
+        self.mde_type_background_integrated = QRadioButton("Background (angle integrated)")
+        self.mde_type_background_integrated.setObjectName("mde_type_background_integrated")
+        self.mde_type_background_minimized = QRadioButton("Background (minimized by angle and energy)")
+        self.mde_type_background_minimized.setObjectName("mde_type_background_minimized")
+        # group the radio buttons to ensure mutually exclusive selection
+        self.mde_type_button_group = QButtonGroup()
+        self.mde_type_button_group.addButton(self.mde_type_data)
+        self.mde_type_button_group.addButton(self.mde_type_background_integrated)
+        self.mde_type_button_group.addButton(self.mde_type_background_minimized)
+        self.layout.addWidget(mde_type_label, 3, 0)
+        self.layout.addWidget(self.mde_type_data, 3, 1)
+        self.layout.addWidget(self.mde_type_background_integrated, 4, 1)
+        self.layout.addWidget(self.mde_type_background_minimized, 5, 1)
+
+        self.layout.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 6, 0)
+
+        self.setLayout(self.layout)
 
 
 class ReductionParameters(QGroupBox):

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -1,4 +1,5 @@
 """PyQt widget for the histogram tab"""
+import re
 from qtpy.QtWidgets import (
     QWidget,
     QVBoxLayout,
@@ -31,9 +32,15 @@ class Generate(QWidget):
 
         layout.addWidget(RawData(self), 1, 1)
         layout.addWidget(Oncat(self), 2, 1)
-        layout.addWidget(MDEType(self), 1, 2)
+        self.mde_type_widget = MDEType(self)
+        layout.addWidget(self.mde_type_widget, 1, 2)
         layout.addWidget(ReductionParameters(self), 2, 2)
-        layout.addWidget(Buttons(self), 1, 3, 2, 1)
+
+        self.buttons = Buttons(self)
+        layout.addWidget(self.buttons, 1, 3, 2, 1)
+        # connect to as_dict for user to see the dict before the saving
+        # is fully implemented.
+        self.buttons.save_btn.clicked.connect(self.mde_type_widget.as_dict)
 
         self.setLayout(layout)
 
@@ -113,6 +120,60 @@ class MDEType(QGroupBox):
             self._output_dir = directory
             self.output_dir.setText(directory)
 
+    def check_mde_name(self) -> bool:
+        """Check if the mde name is valid.
+
+        Returns:
+        --------
+            bool: True if the mde name is valid, False otherwise.
+        """
+        mde_name = self.mde_name.text()
+
+        if is_valid_name(mde_name):
+            self._mde_name = mde_name
+            return True
+
+        return False
+
+    def check_output_dir(self) -> bool:
+        """Check if the output directory is valid.
+
+        Returns:
+        --------
+        bool:
+            True if the output directory is not empty and does not contains any
+            special char, False otherwise.
+        """
+        output_dir = self.output_dir.text()
+
+        if output_dir == "":
+            return False
+
+        if has_special_char(output_dir):
+            return False
+
+        self._output_dir = output_dir
+        return True
+
+    @property
+    def is_valid(self) -> bool:
+        """Check if the MDE type widget is valid."""
+        return self.check_mde_name() and self.check_output_dir()
+
+    def as_dict(self) -> dict:
+        """Return the MDE type widget as a dictionary."""
+        if self.is_valid:
+            rst = {
+                "mde_name": self._mde_name,
+                "output_dir": self._output_dir,
+                "mde_type": self.mde_type_button_group.checkedButton().text(),
+            }
+        else:
+            rst = {}
+
+        print(rst)
+        return rst
+
 
 class ReductionParameters(QGroupBox):
     """Generate reduction parameter widget"""
@@ -129,7 +190,56 @@ class Buttons(QWidget):
         super().__init__(parent)
 
         layout = QVBoxLayout()
-        layout.addWidget(QPushButton("Generate"))
-        layout.addWidget(QPushButton("Save settings"))
+        self.generate_btn = QPushButton("Generate")
+        layout.addWidget(self.generate_btn)
+        self.save_btn = QPushButton("Save settings")
+        layout.addWidget(self.save_btn)
         layout.addStretch()
         self.setLayout(layout)
+
+
+def is_valid_name(var_name: str) -> bool:
+    """Check if the variable name is valid.
+
+    Parameters:
+    -----------
+    var_name: str
+        The variable name to check.
+
+    Returns:
+    --------
+    bool:
+        True if the variable name is valid, False otherwise.
+
+    NOTE:
+    -----
+        The variable name must follow the following rules:
+        - must not be empty
+        - must start with a letter or underscore
+        - must only contain letters, numbers, and underscores
+    """
+    if not var_name:
+        return False
+    if not var_name[0].isalpha() and var_name[0] != "_":
+        return False
+    for char in var_name:
+        if not char.isalnum() and char != "_":
+            return False
+    return True
+
+
+def has_special_char(var_name: str) -> bool:
+    """Check if the variable name contains special characters.
+
+    Parameters:
+    -----------
+    var_name: str
+        The variable name to check.
+
+    Returns:
+    --------
+    bool:
+        True if the variable name contains special characters, False otherwise.
+    """
+    regex = re.compile("[@!#$%^&*()<>?|}{~]")
+    return regex.search(var_name) is not None

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -54,7 +54,7 @@ class Generate(QWidget):
         layout.addWidget(self.buttons, 1, 3, 2, 1)
         # connect to as_dict for user to see the dict before the saving
         # is fully implemented.
-        self.buttons.save_btn.clicked.connect(self.mde_type_widget.as_dict)
+        self.buttons.save_btn.clicked.connect(self.as_dict)
 
         self.setLayout(layout)
 

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -209,8 +209,56 @@ class MDEType(QGroupBox):
         else:
             rst = {}
 
-        print(rst)
         return rst
+
+    def populate_from_dict(self, param_dict: dict) -> bool:
+        """Populate the MDE type widget from a dictionary.
+
+        Parameters:
+        -----------
+        param_dict: dict
+            The dictionary containing the MDE type widget parameters.
+
+        Returns:
+        --------
+        bool:
+            True if the MDE type widget is populated successfully, False otherwise.
+        """
+        mde_name = param_dict.get("mde_name", "")
+        output_dir = param_dict.get("output_dir", "")
+        mde_type = param_dict.get("mde_type", "")
+
+        # sanity check before assigning values
+        # mde name must be valid
+        if not is_valid_name(mde_name):
+            if self.error_callback:
+                self.error_callback("Invalid MDE name found in history.")
+            return False
+        # output directory must be valid
+        if output_dir == "" or has_special_char(output_dir):
+            if self.error_callback:
+                self.error_callback("Invalid output directory found in history.")
+            return False
+        # mde type must be valid
+        if mde_type not in ["Data", "Background (angle integrated)", "Background (minimized by angle and energy)"]:
+            if self.error_callback:
+                self.error_callback("Invalid MDE type found in history.")
+            return False
+
+        # assign values
+        self.mde_name.setText(mde_name)
+        self.output_dir.setText(output_dir)
+        if mde_type == "Data":
+            self.mde_type_data.setChecked(True)
+        elif mde_type == "Background (angle integrated)":
+            self.mde_type_background_integrated.setChecked(True)
+        elif mde_type == "Background (minimized by angle and energy)":
+            self.mde_type_background_minimized.setChecked(True)
+        else:
+            # this should never happen
+            raise RuntimeError("Invalid MDE type found in history.")
+
+        return True
 
     def connect_error_callback(self, callback):
         """Connect the error callback.

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -11,6 +11,7 @@ from qtpy.QtWidgets import (
     QSizePolicy,
     QButtonGroup,
     QRadioButton,
+    QFileDialog,
 )
 from .data import RawData
 
@@ -53,6 +54,10 @@ class MDEType(QGroupBox):
         self.setTitle("MDE type")
         self.layout = QGridLayout()
 
+        # cached values
+        self._mde_name = None
+        self._output_dir = None
+
         # mde name (label) and input
         mde_name_label = QLabel("MDE name")
         self.mde_name = QLineEdit("")
@@ -72,6 +77,8 @@ class MDEType(QGroupBox):
         self.layout.addWidget(output_dir_label, 1, 0)
         self.layout.addWidget(self.output_dir, 1, 1)
         self.layout.addWidget(browse_button, 1, 2)
+        # connect the browse button to the browse function
+        browse_button.clicked.connect(self._browse)
 
         # add a small gap between the two sections
         self.layout.addItem(QSpacerItem(0, 10, QSizePolicy.Minimum, QSizePolicy.Minimum), 2, 0)
@@ -98,6 +105,13 @@ class MDEType(QGroupBox):
         self.layout.addItem(QSpacerItem(0, 0, QSizePolicy.Minimum, QSizePolicy.Expanding), 6, 0)
 
         self.setLayout(self.layout)
+
+    def _browse(self):
+        """Browse for output directory"""
+        directory = QFileDialog.getExistingDirectory(self, "Select output directory")
+        if directory != self._output_dir:
+            self._output_dir = directory
+            self.output_dir.setText(directory)
 
 
 class ReductionParameters(QGroupBox):

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -178,7 +178,7 @@ class MDEType(QGroupBox):
             True if the output directory is not empty and does not contains any
             special char, False otherwise.
         """
-        output_dir = self.output_dir.text()
+        output_dir = self.output_dir.text().strip()
 
         if output_dir == "":
             if self.error_callback:
@@ -269,6 +269,12 @@ class MDEType(QGroupBox):
             The error callback.
         """
         self.error_callback = callback
+
+    def re_init_widget(self):
+        """Re-initialize the widget."""
+        self.mde_name.setText("")
+        self.output_dir.setText("")
+        self.mde_type_data.setChecked(True)
 
 
 class ReductionParameters(QGroupBox):

--- a/tests/views/test_generate.py
+++ b/tests/views/test_generate.py
@@ -74,21 +74,21 @@ def test_mde_type_widget(qtbot):
     # check error_1: invalid mde name
     mde_type_widget.re_init_widget()
     mde_type_widget.mde_name.setText("test?")
-    assert mde_type_widget.as_dict() == {}
+    assert not mde_type_widget.as_dict()
     assert errors_list[-1] == "Invalid MDE name."
 
     # check error_2: empty output dir
     mde_type_widget.re_init_widget()
     mde_type_widget.mde_name.setText("test")
     mde_type_widget.output_dir.setText(" ")
-    assert mde_type_widget.as_dict() == {}
+    assert not mde_type_widget.as_dict()
     assert errors_list[-1] == "Output directory cannot be empty."
 
     # check error_3: invalid output dir
     mde_type_widget.re_init_widget()
     mde_type_widget.mde_name.setText("test")
     mde_type_widget.output_dir.setText("/tmp/test?")
-    assert mde_type_widget.as_dict() == {}
+    assert not mde_type_widget.as_dict()
     assert errors_list[-1] == "Output directory cannot contain special characters."
 
     # check error_4: invalid dict used to populate UI

--- a/tests/views/test_generate.py
+++ b/tests/views/test_generate.py
@@ -1,0 +1,113 @@
+#!/usr/env/bin python
+"""Test the generate view."""
+import pytest
+from shiver.views.generate import (
+    MDEType,
+    is_valid_name,
+    has_special_char,
+)
+
+
+def test_mde_name_check():
+    """Test the mde name check."""
+    assert is_valid_name("test") is True
+    assert is_valid_name("_test") is True
+    assert is_valid_name("test0") is True
+    assert is_valid_name("0test") is False
+    assert is_valid_name("?test_0") is False
+    assert is_valid_name("test?_0") is False
+    assert is_valid_name("test-0") is False
+
+def test_path_check():
+    """Test the path check function."""
+    assert has_special_char("/tmp/test") is False
+    assert has_special_char("/tmp/test?") is True
+    assert has_special_char("/tmp/test/me#") is True
+    assert has_special_char("C:\\tmp") is False
+
+def test_mde_type_widget(qtbot):
+    """Test for the generate widget (view)."""
+    mde_type_widget = MDEType()
+    qtbot.addWidget(mde_type_widget)
+    mde_type_widget.show()
+
+    errors_list = []
+    def error_callback(msg):
+        """Callback for error."""
+        errors_list.append(msg)
+
+    mde_type_widget.connect_error_callback(error_callback)
+
+    # check happy path (ui -> dict)
+    mde_type_widget.mde_name.setText("test")
+    mde_type_widget.output_dir.setText("/tmp/test")
+    mde_type_widget.mde_type_background_integrated.setChecked(True)
+    rst_dict = mde_type_widget.as_dict()
+    #
+    ref_dict = {
+        "mde_name": "test",
+        "output_dir": "/tmp/test",
+        "mde_type": "Background (angle integrated)",
+    }
+    #
+    assert rst_dict == ref_dict
+
+    # check happy path (dict -> ui)
+    mde_type_widget.re_init_widget()
+    mde_type_widget.populate_from_dict(ref_dict)
+    #
+    assert mde_type_widget.mde_name.text() == "test"
+    assert mde_type_widget.output_dir.text() == "/tmp/test"
+    assert mde_type_widget.mde_type_background_integrated.isChecked() is True
+    #
+    ref_dict["mde_type"] = "Data"
+    mde_type_widget.populate_from_dict(ref_dict)
+    assert mde_type_widget.mde_type_data.isChecked() is True
+    #
+    ref_dict["mde_type"] = "Background (minimized by angle and energy)"
+    mde_type_widget.populate_from_dict(ref_dict)
+    assert mde_type_widget.mde_type_background_minimized.isChecked() is True
+
+    # check error_1: invalid mde name
+    mde_type_widget.re_init_widget()
+    mde_type_widget.mde_name.setText("test?")
+    assert mde_type_widget.as_dict() == {}
+    assert errors_list[-1] == "Invalid MDE name."
+
+    # check error_2: empty output dir
+    mde_type_widget.re_init_widget()
+    mde_type_widget.mde_name.setText("test")
+    mde_type_widget.output_dir.setText(" ")
+    assert mde_type_widget.as_dict() == {}
+    assert errors_list[-1] == "Output directory cannot be empty."
+
+    # check error_3: invalid output dir
+    mde_type_widget.re_init_widget()
+    mde_type_widget.mde_name.setText("test")
+    mde_type_widget.output_dir.setText("/tmp/test?")
+    assert mde_type_widget.as_dict() == {}
+    assert errors_list[-1] == "Output directory cannot contain special characters."
+
+    # check error_4: invalid dict used to populate UI
+    mde_type_widget.re_init_widget()
+    mde_type_widget.populate_from_dict({"mde_name": "test?"})
+    assert errors_list[-1] == "Invalid MDE name found in history."
+    #
+    mde_type_widget.re_init_widget()
+    mde_type_widget.populate_from_dict({
+        "mde_name": "test",
+        "output_dir": "/tmp/test?",
+        })
+    assert errors_list[-1] == "Invalid output directory found in history."
+    #
+    mde_type_widget.re_init_widget()
+    mde_type_widget.populate_from_dict({
+        "mde_name": "test",
+        "output_dir": "/tmp/test",
+        "mde_type": "Data_",
+    })
+    assert errors_list[-1] == "Invalid MDE type found in history."
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/views/test_generate.py
+++ b/tests/views/test_generate.py
@@ -18,12 +18,14 @@ def test_mde_name_check():
     assert is_valid_name("test?_0") is False
     assert is_valid_name("test-0") is False
 
+
 def test_path_check():
     """Test the path check function."""
     assert has_special_char("/tmp/test") is False
     assert has_special_char("/tmp/test?") is True
     assert has_special_char("/tmp/test/me#") is True
     assert has_special_char("C:\\tmp") is False
+
 
 def test_mde_type_widget(qtbot):
     """Test for the generate widget (view)."""
@@ -32,6 +34,7 @@ def test_mde_type_widget(qtbot):
     mde_type_widget.show()
 
     errors_list = []
+
     def error_callback(msg):
         """Callback for error."""
         errors_list.append(msg)
@@ -94,18 +97,22 @@ def test_mde_type_widget(qtbot):
     assert errors_list[-1] == "Invalid MDE name found in history."
     #
     mde_type_widget.re_init_widget()
-    mde_type_widget.populate_from_dict({
-        "mde_name": "test",
-        "output_dir": "/tmp/test?",
-        })
+    mde_type_widget.populate_from_dict(
+        {
+            "mde_name": "test",
+            "output_dir": "/tmp/test?",
+        }
+    )
     assert errors_list[-1] == "Invalid output directory found in history."
     #
     mde_type_widget.re_init_widget()
-    mde_type_widget.populate_from_dict({
-        "mde_name": "test",
-        "output_dir": "/tmp/test",
-        "mde_type": "Data_",
-    })
+    mde_type_widget.populate_from_dict(
+        {
+            "mde_name": "test",
+            "output_dir": "/tmp/test",
+            "mde_type": "Data_",
+        }
+    )
     assert errors_list[-1] == "Invalid MDE type found in history."
 
 


### PR DESCRIPTION
This PR introduces the following changes:

- implement MDE type widget
- add error handling for generate tab
- add corresponding unit tests

To test
---------

- clone the feature branch and perform editable install as described in Readme
- switch to generate tab
  -  click `Save settings` and it should trigger a warning about invalid MDE name
  ![image](https://user-images.githubusercontent.com/5064852/232861753-60f8a47e-f08e-40d7-9f7c-ad80de8339c1.png)
  - enter "test" for mde name, and click again, it should trigger an empty path error
  ![image](https://user-images.githubusercontent.com/5064852/232861982-f2dc2625-ab80-40f7-8d2c-7c3186bb6668.png)
  - put "/tmp/test#" in path, click again, it should trigger an invalid path error
  ![image](https://user-images.githubusercontent.com/5064852/232862212-0b103137-eba6-479d-8682-75b98a820189.png)
  - click browse and select a folder, the field should be updated, click "Save settings` again, no error should show up.

> IBM item: [Story942](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=942)