### PR TITLE
Fix error handling for incorrect symmetry operations

### DIFF
--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -196,7 +196,9 @@ class HistogramModel:
                     err_msg = f"Invalid symmetry value: {symmetry}::{err} \n"
                     logger.error(err_msg)
                     if self.error_callback:
-                        self.error_callback(err_msg)
+                        self.error_callback(err_msg, accumulate=True)
+                    return False
+        return True
 
     def ws_change_call_back(self, callback):
         """Set the callback function for workspace changes"""

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -69,11 +69,11 @@ class HistogramPresenter:
     def handle_button(self, params_dict):
         """Validate symmetry histogram parameter"""
         symmetry = params_dict["SymmetryOperations"]
-        self.model.symmetry_operations(symmetry)
+        return self.model.symmetry_operations(symmetry)
 
-    def error_message(self, msg):
+    def error_message(self, msg, **kwargs):
         """Pass error message to the view"""
-        self.view.show_error_message(msg)
+        self.view.show_error_message(msg, **kwargs)
 
     def ws_changed(self, action, name, ws_type, frame=None, ndims=0):
         """Pass the workspace change to the view"""

--- a/src/shiver/views/histogram.py
+++ b/src/shiver/views/histogram.py
@@ -15,6 +15,7 @@ class Histogram(QWidget):
     """Histogram widget"""
 
     error_message_signal = Signal(str)
+    msg_queue = []
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -35,11 +36,24 @@ class Histogram(QWidget):
 
         self.buttons.connect_error_msg(self.show_error_message)
 
-    def show_error_message(self, msg):
-        """Will show a error dialog with the given message
+    def show_error_message(self, msg, accumulate=False):
+        """Will show a error dialog with the given message.
 
-        This will emit a signal so that other threads can call this but have the GUI thread execute"""
-        self.error_message_signal.emit(msg)
+        This will emit a signal so that other threads can call this but have the GUI thread execute it.
+
+        Parameters
+        ----------
+        msg : str
+            The message to show
+        accumulate : bool, optional
+            If True, the error message will be accumulated and shown when accumulate is False
+        """
+        if not accumulate:
+            msg = '\n'.join(self.msg_queue) + '\n' + msg
+            self.error_message_signal.emit(msg)
+            self.msg_queue = []
+        else:
+            self.msg_queue.append(msg)
 
     def _show_error_message(self, msg):
         """Will show a error dialog with the given message from qt signal"""

--- a/src/shiver/views/histogram.py
+++ b/src/shiver/views/histogram.py
@@ -49,7 +49,7 @@ class Histogram(QWidget):
             If True, the error message will be accumulated and shown when accumulate is False
         """
         if not accumulate:
-            msg = '\n'.join(self.msg_queue) + '\n' + msg
+            msg = "\n".join(self.msg_queue) + "\n" + msg
             self.error_message_signal.emit(msg)
             self.msg_queue = []
         else:

--- a/src/shiver/views/histogram_parameters.py
+++ b/src/shiver/views/histogram_parameters.py
@@ -208,8 +208,19 @@ class HistogramParameter(QGroupBox):
         -------
             bool -- True if valid, False otherwise
         """
+        # check if step values are valid
         step_valid_state = self.dimensions.steps_valid_state()
-        return self.projections_valid_state and len(self.dimensions.min_max_invalid_states) == 0 and step_valid_state
+
+        # check if symmetry is valid
+        # NOTE: the symmetry checking is done in histogram_callback, and the
+        #       actual checking is done in histogram.model.
+        #       the current design requires packing the data as a dictionary,
+        #       so we pack it here.
+        parameters = {}
+        parameters["SymmetryOperations"] = self.symmetry_operations.text()
+        sym_valid_state = self.histogram_callback(parameters) if self.histogram_callback else False
+
+        return self.projections_valid_state and len(self.dimensions.min_max_invalid_states) == 0 and step_valid_state and sym_valid_state
 
     def projection_to_hkl(self, projection: str) -> str:
         """Converts the projection to H,K,L
@@ -291,10 +302,6 @@ class HistogramParameter(QGroupBox):
 
             parameters["SymmetryOperations"] = self.symmetry_operations.text()
             parameters["Smoothing"] = self.smoothing.text()
-
-            # perform symmetry validate via callback
-            # NOTE: the validation code is in a model due to MVP design
-            self.histogram_callback(parameters)
 
         return parameters
 

--- a/src/shiver/views/histogram_parameters.py
+++ b/src/shiver/views/histogram_parameters.py
@@ -220,7 +220,12 @@ class HistogramParameter(QGroupBox):
         parameters["SymmetryOperations"] = self.symmetry_operations.text()
         sym_valid_state = self.histogram_callback(parameters) if self.histogram_callback else False
 
-        return self.projections_valid_state and len(self.dimensions.min_max_invalid_states) == 0 and step_valid_state and sym_valid_state
+        return (
+            self.projections_valid_state
+            and len(self.dimensions.min_max_invalid_states) == 0
+            and step_valid_state
+            and sym_valid_state
+        )
 
     def projection_to_hkl(self, projection: str) -> str:
         """Converts the projection to H,K,L

--- a/tests/models/test_symmetry_operations.py
+++ b/tests/models/test_symmetry_operations.py
@@ -58,7 +58,7 @@ def test_symmetry_invalid():
     """test for loading MDE file"""
     errors = []
 
-    def error_callback(msg):
+    def error_callback(msg, **kwargs):  # pylint: disable=unused-argument
         errors.append(msg)
 
     model = HistogramModel()

--- a/tests/views/test_histogram_button.py
+++ b/tests/views/test_histogram_button.py
@@ -61,6 +61,12 @@ def test_dictionary_creation_histogram_btn(qtbot):
 
     qtbot.mouseClick(histogram_parameters.histogram_btn, QtCore.Qt.LeftButton)
 
+    # need to patch the call to the model for checking symmetry operations
+    def mock_symmetry_operations(symmetry_operations):  # pylint: disable=unused-argument
+        return True
+
+    histogram_parameters.histogram_callback = mock_symmetry_operations
+
     params = histogram_parameters.gather_histogram_parameters()
 
     ref_params = {


### PR DESCRIPTION
## This PR introduces the following changes:

- fix an issue where incorrect symmetry operation is detected, but still leads to shiver crashing.
- allow error messages to be accumulated before popping.
- update corresponding unit tests.

## Testing instruction
- clone the feature branch and setup the dev env as instructed in Readme.
- Setup data, background, and normalization workspace (use the Load Dataset button to run the pre-defined dataset script)
  ![image](https://user-images.githubusercontent.com/5064852/234048182-e388713a-1cce-428d-9f0d-9848e6ef726a.png)
- Type incorrect symmetries (see below)
  ![image](https://user-images.githubusercontent.com/5064852/234048327-01263b31-6f6d-492d-b04b-9204114c9f1b.png)
- Hit the histogram button, and an error message should popup
  ![image](https://user-images.githubusercontent.com/5064852/234048493-ddd56f0d-b035-434e-b1a7-b21a1161a377.png)
- Closing the error message window should not crash shiver.

> IBM item: [Defect1281](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=1281&tab=gov.ornl.neutron.workitem.defect.tab.overview)