### PR TITLE
Add progress reporting to MakeSlice

### DIFF
--- a/src/shiver/models/makeslice.py
+++ b/src/shiver/models/makeslice.py
@@ -155,9 +155,10 @@ class MakeSlice(DataProcessorAlgorithm):
                 mdnorm_bkg_parameters["OutputDataWorkspace"] = "_bkg_data"
                 mdnorm_bkg_parameters["OutputNormalizationWorkspace"] = "_bkg_norm"
                 bg_type = "sample"
-                MDNorm(**mdnorm_bkg_parameters)
+                MDNorm(**mdnorm_bkg_parameters, startProgress=0, endProgress=0.5)
 
-        MDNorm(**mdnorm_parameters)
+        MDNorm(**mdnorm_parameters, startProgress=0.5 if bg_mde_name else 0, endProgress=1)
+
         SmoothingFWHM = self.getProperty("Smoothing").value
         if SmoothingFWHM == Property.EMPTY_DBL:
             SmoothingFWHM = None


### PR DESCRIPTION
Most of the time is spent running MDNorm so just expose its progress.

To test, load the test MDE, using 1D set the step to something small like 0.001, so you have time to see the progress, press Histogram.

[940](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=940)