### PR TITLE
Implement saving data to ASCII

### DIFF
--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -199,7 +199,7 @@ class HistogramModel:
         err = np.sqrt(err2)
 
         # write file
-        header = "Intensity Error " + " ".join([d.getName() for d in dims])
+        header = "Intensity Error " + " ".join([d.name for d in dims])
         header += "\n shape: " + "x".join([str(d.getNBins()) for d in dims])
         to_print = np.c_[data.flatten(), err.flatten()]
         for dim in newdimarrays:

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -138,7 +138,7 @@ class HistogramModel:
         self,
         ws_name: str,
         filename: str,
-        ignore_integrated: bool = True,
+        ignore_integrated: bool = False,
         num_ev_norm: bool = False,
         format_str: str = "%.6e",
     ):
@@ -152,7 +152,7 @@ class HistogramModel:
             Name of the file to save to.
         IgnoreIntegrated : bool, optional
             If True, the integrated dimensions are ignored (smaller files), but that information is lost
-            (default is True).
+            (default is False).
         NumEvNorm : bool, optional
             Must be set to true if data was converted to MD from a histogram workspace (like NXSPE)
             and no MDNorm algorithms were used.

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -2,6 +2,7 @@
 import time
 import os.path
 from typing import Tuple
+import numpy as np
 
 # pylint: disable=no-name-in-module
 from mantid.api import AlgorithmManager, AlgorithmObserver, AnalysisDataServiceObserver
@@ -130,8 +131,80 @@ class HistogramModel:
         RenameWorkspace(old_name, new_name)
 
     def save(self, ws_name, filename):
-        """Save the workspace"""
+        """Save the workspace to Nexus file."""
         SaveMD(ws_name, filename)
+
+    def save_to_ascii(
+        self,
+        ws_name: str,
+        filename: str,
+        ignore_integrated: bool = True,
+        num_ev_norm: bool = False,
+        format_str: str = "%.6e",
+    ):
+        """Save an MDHistoToWorkspace to an ascii file (column format).
+
+        Parameters
+        ----------
+        ws_name : str
+            Name of the workspace to save.
+        filename : str
+            Name of the file to save to.
+        IgnoreIntegrated : bool, optional
+            If True, the integrated dimensions are ignored (smaller files), but that information is lost
+            (default is True).
+        NumEvNorm : bool, optional
+            Must be set to true if data was converted to MD from a histogram workspace (like NXSPE)
+            and no MDNorm algorithms were used.
+        format_str : str, optional
+            Format string for the output (default is "%.6e").
+
+        NOTE
+        ----
+        This function is adapted from DGS_SC_scripts/slice_util.py::SaveMDToAscii.
+        """
+        # sanity check (workspace must exist)
+        if not mtd.doesExist(ws_name):
+            if self.error_callback:
+                self.error_callback(f"Workspace {ws_name} no longer exist in memory.")
+            return
+
+        workspace = mtd[ws_name]
+
+        # sanity check (workspace must be an MDHistoWorkspace)
+        if workspace.id() != "MDHistoWorkspace":
+            if self.error_callback:
+                self.error_callback(f"Workspace {ws_name} is not an MDHistoWorkspace.")
+            return
+
+        # get dimensions
+        if ignore_integrated:
+            dims = workspace.getNonIntegratedDimensions()
+        else:
+            dims = [workspace.getDimension(i) for i in range(workspace.getNumDims())]
+        dimarrays = [dim2array(d) for d in dims]
+
+        if len(dimarrays) > 1:
+            newdimarrays = np.meshgrid(*dimarrays, indexing="ij")
+        else:
+            newdimarrays = dimarrays
+
+        # get data
+        data = workspace.getSignalArray() * 1.0
+        err2 = workspace.getErrorSquaredArray() * 1.0
+        if num_ev_norm:
+            nev = workspace.getNumEventsArray()
+            data /= nev
+            err2 /= nev * nev
+        err = np.sqrt(err2)
+
+        # write file
+        header = "Intensity Error " + " ".join([d.getName() for d in dims])
+        header += "\n shape: " + "x".join([str(d.getNBins()) for d in dims])
+        to_print = np.c_[data.flatten(), err.flatten()]
+        for dim in newdimarrays:
+            to_print = np.c_[to_print, dim.flatten()]
+        np.savetxt(filename, to_print, fmt=format_str, header=header)
 
     def save_history(self, ws_name, filename):
         """Save the mantid algorithm history"""
@@ -439,3 +512,25 @@ def get_frame(name):
 def get_num_non_integrated_dims(name):
     """Returns the number of non-integrated dimensions"""
     return len(mtd[name].getNonIntegratedDimensions())
+
+
+def dim2array(dim, center=True) -> np.ndarray:
+    """
+    Create a numpy array containing bin centers along the dimension d.
+
+    Parameters
+    ----------
+    dim: IMDDimension
+    center: bool, optional
+
+    Returns
+    -------
+        from min+st/2 to max-st/2 with step st
+    """
+    dmin = dim.getMinimum()
+    dmax = dim.getMaximum()
+    dstep = dim.getX(1) - dim.getX(0)
+    if center:
+        return np.arange(dmin + dstep / 2, dmax, dstep)
+
+    return np.linspace(dmin, dmax, dim.getNBins() + 1)

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -20,6 +20,7 @@ class HistogramPresenter:
         self.view.connect_delete_workspace(self.delete_workspace)
         self.view.connect_rename_workspace(self.rename_workspace)
         self.view.connect_save_workspace(self.save_workspace)
+        self.view.connect_save_workspace_to_ascii(self.save_workspace_to_ascii)
         self.view.connect_save_script_workspace(self.save_workspace_history)
         self.view.connect_corrections_tab(self.create_corrections_tab)
         self.model.connect_error_message(self.error_message)
@@ -95,6 +96,10 @@ class HistogramPresenter:
     def save_workspace(self, name, filename):
         """Called by the view to save a workspace"""
         self.model.save(name, filename)
+
+    def save_workspace_to_ascii(self, name, filename):
+        """Called by the view to save a workspace to ascii."""
+        self.model.save_to_ascii(name, filename)
 
     def save_workspace_history(self, name, filename):
         """Called by the view to rename a workspace"""

--- a/src/shiver/views/histogram.py
+++ b/src/shiver/views/histogram.py
@@ -91,6 +91,10 @@ class Histogram(QWidget):
         """connect a function to the save a workspace"""
         self.histogram_workspaces.histogram_workspaces.save_callback = callback
 
+    def connect_save_workspace_to_ascii(self, callback):
+        """connect a function to the save a workspace to ascii"""
+        self.histogram_workspaces.histogram_workspaces.save_to_ascii_callback = callback
+
     def connect_save_script_workspace(self, callback):
         """connect a function to the save script for workspace"""
         self.histogram_workspaces.histogram_workspaces.save_script_callback = callback

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -496,22 +496,12 @@ class MDHList(ADSList):
             self, "Select location to save workspace", "", "ASCII file (*.dat);;All files (*)"
         )
         if filename and self.save_to_ascii_callback:
-            self.save_to_ascii_callback(name, filename)
+            self.save_to_ascii_callback(name, filename)  # pylint: disable=not-callable
 
     def delete_ws(self, name):
         """Method to delete the currently selected workspace."""
         if self.delete_workspace_callback:
             self.delete_workspace_callback(name)  # pylint: disable=not-callable
-
-    def connect_save_to_ascii_callback(self, callback):
-        """Method to connect the save to ascii callback.
-
-        Parameters
-        ----------
-        callback
-            callback function
-        """
-        self.save_to_ascii_callback = callback
 
 
 def get_icon(name: str) -> QIcon:

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -378,7 +378,9 @@ class MDHList(ADSList):
         self.delete_workspace_callback = None
         self.setContextMenuPolicy(Qt.CustomContextMenu)
         self.customContextMenuRequested.connect(self.contextMenu)
+
         self.save_callback = None
+        self.save_to_ascii_callback = None
         self.save_script_callback = None
         self.plot_callback = None
 
@@ -425,9 +427,13 @@ class MDHList(ADSList):
         script.triggered.connect(partial(self.save_script, selected_ws))
         menu.addAction(script)
 
-        save = QAction("Save Data")
+        save = QAction("Save Nexus Data")
         save.triggered.connect(partial(self.save_ws, selected_ws))
         menu.addAction(save)
+
+        save_ascii = QAction("Save ASCII Data")
+        save_ascii.triggered.connect(partial(self.save_ws_to_ascii, selected_ws))
+        menu.addAction(save_ascii)
 
         menu.addSeparator()
 
@@ -464,18 +470,48 @@ class MDHList(ADSList):
         if filename and self.save_script_callback:
             self.save_script_callback(name, filename)  # pylint: disable=not-callable
 
-    def save_ws(self, name):
-        """method to handle the saving of script"""
+    def save_ws(self, name: str):
+        """Method to handle the saving data to NeXus file.
+
+        Parameters
+        ----------
+        name
+            name of the workspace to be saved
+        """
         filename, _ = QFileDialog.getSaveFileName(
             self, "Select location to save workspace", "", "NeXus file (*.nxs);;All files (*)"
         )
         if filename and self.save_callback:
             self.save_callback(name, filename)  # pylint: disable=not-callable
 
+    def save_ws_to_ascii(self, name: str):
+        """Method to handle the saving data to ASCII file.
+
+        Parameters
+        ----------
+        name
+            name of the workspace to be saved
+        """
+        filename, _ = QFileDialog.getSaveFileName(
+            self, "Select location to save workspace", "", "ASCII file (*.dat);;All files (*)"
+        )
+        if filename and self.save_to_ascii_callback:
+            self.save_to_ascii_callback(name, filename)
+
     def delete_ws(self, name):
-        """method to delete the currently selected workspace"""
+        """Method to delete the currently selected workspace."""
         if self.delete_workspace_callback:
             self.delete_workspace_callback(name)  # pylint: disable=not-callable
+
+    def connect_save_to_ascii_callback(self, callback):
+        """Method to connect the save to ascii callback.
+
+        Parameters
+        ----------
+        callback
+            callback function
+        """
+        self.save_to_ascii_callback = callback
 
 
 def get_icon(name: str) -> QIcon:

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -495,6 +495,11 @@ class MDHList(ADSList):
         filename, _ = QFileDialog.getSaveFileName(
             self, "Select location to save workspace", "", "ASCII file (*.dat);;All files (*)"
         )
+
+        # check if filename has a .dat or .csv extension
+        if filename and not (filename.endswith(".dat") or filename.endswith(".csv")):
+            filename += ".dat"
+
         if filename and self.save_to_ascii_callback:
             self.save_to_ascii_callback(name, filename)  # pylint: disable=not-callable
 

--- a/tests/models/test_save.py
+++ b/tests/models/test_save.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+"""Test save methods in histogram model."""
+import os
+import pytest
+from mantid.simpleapi import LoadMD  # pylint: disable=no-name-in-module
+from shiver.models.histogram import HistogramModel
+
+
+def test_save_to_ascii(tmp_path):
+    """Unit test for exporting MDHistoWorkspace to ASCII file."""
+    # load the testing MDHistoWorkspace from test/data folder
+    filename = os.path.join(
+        os.path.dirname(__file__),
+        "../data/hist",
+        "plot_1.nxs.h5",
+    )
+    LoadMD(filename, OutputWorkspace="plot_1")
+
+    model = HistogramModel()
+
+    # save the MDHistoWorkspace to ASCII file
+    save_filename = str(tmp_path / "test_save_to_ascii.dat")
+    model.save_to_ascii("plot_1", save_filename)
+
+    # check if the file exists
+    assert os.path.exists(save_filename)
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/tests/views/test_mdh_workspaces.py
+++ b/tests/views/test_mdh_workspaces.py
@@ -63,7 +63,7 @@ def test_mdh_workspaces_menu(qtbot):
     assert save_script[0][0] == "mdh1"
     assert save_script[0][1].endswith("script.py")
 
-    # right-click first item and select "Save Data"
+    # right-click first item and select "Save NEXUS Data"
     save = []
 
     def save_callback(name, filename):
@@ -83,6 +83,21 @@ def test_mdh_workspaces_menu(qtbot):
     assert save[0][0] == "mdh1"
     assert save[0][1].endswith("workspace.nxs")
 
+    # right-click first item and select "Save ASCII data"
+    save_ascii = []
+
+    def save_ascii_callback(name, filename):
+        save_ascii.append((name, filename))
+
+    mdh_table.save_ascii_callback = save_ascii_callback
+
+    QTimer.singleShot(100, partial(handle_menu, qtbot, mdh_table, 7))
+    QTimer.singleShot(200, partial(handle_dialog, "workspace.txt"))
+
+    QApplication.postEvent(
+        mdh_table.viewport(), QContextMenuEvent(QContextMenuEvent.Mouse, mdh_table.visualItemRect(item).center())
+    )
+
     # right-click first item and select "Delete"
     deleted = []
 
@@ -94,7 +109,7 @@ def test_mdh_workspaces_menu(qtbot):
     item = mdh_table.item(0)
     assert item.text() == "mdh1"
 
-    QTimer.singleShot(100, partial(handle_menu, qtbot, mdh_table, 7))
+    QTimer.singleShot(100, partial(handle_menu, qtbot, mdh_table, 8))
 
     QApplication.postEvent(
         mdh_table.viewport(), QContextMenuEvent(QContextMenuEvent.Mouse, mdh_table.visualItemRect(item).center())


### PR DESCRIPTION
## This PR introduces the following changes:

- add new capability to allow saving MDH to ASCII data
- update the context menu (more explicit on its functionality)

## To Test

- Clone and setup the feature branch following instructions layout in Readme.
- Start shiver and use `LoadDataset` to load data, setup histogram parameters and press `Histogram`.
  ![image](https://user-images.githubusercontent.com/5064852/234369271-bf81fcb5-1e10-43d7-89c6-d8460eebc1f4.png)
- Right click on `Plot_1` and select `Save ASCII Data`
  ![image](https://user-images.githubusercontent.com/5064852/234369455-e861fc98-f306-4e9c-9118-b09160eb7978.png)
- Select path and save the data to disk.
- Verify that the data is saved to disk.


> IBM item: [Story1288](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=1288)