### PR TITLE
OnCat widget

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,3 +10,6 @@ dependencies:
  - pytest=7.2.1
  - pytest-qt=4.2.0
  - pytest-cov=4.0.0
+ - pip
+ - pip:
+   - https://oncat.ornl.gov/packages/pyoncat-1.4.1-py3-none-any.whl

--- a/src/shiver/views/data.py
+++ b/src/shiver/views/data.py
@@ -60,7 +60,9 @@ class RawData(QGroupBox):
         self.directory = directory
         self.path.setText(directory)
         self.files.clear()
-        filenames = glob.iglob(os.path.join(directory, "*.nxs.h5"))
+        filenames = list(glob.iglob(os.path.join(directory, "*.nxs.h5")))
+        # also support legacy format (if present)
+        filenames += list(glob.iglob(os.path.join(directory, "*_event.nxs")))
         self.files.addItems([os.path.basename(f) for f in filenames])
 
     def get_selected(self):

--- a/src/shiver/views/data.py
+++ b/src/shiver/views/data.py
@@ -47,6 +47,9 @@ class RawData(QGroupBox):
         layout.addWidget(self.files)
         self.setLayout(layout)
 
+        self.selected_list_from_oncat = None
+        self.inhibit_selection = False
+
     def _path_edited(self):
         if self.path.text() != self.directory:
             self._update_file_list(self.path.text())
@@ -67,7 +70,10 @@ class RawData(QGroupBox):
 
     def get_selected(self):
         """Return a list of the full path of the files selected"""
-        return [os.path.join(self.directory, f.text()) for f in self.files.selectedItems()]
+        if self.selected_list_from_oncat:
+            return self.selected_list_from_oncat
+        else:
+            return [os.path.join(self.directory, f.text()) for f in self.files.selectedItems()]
 
     def set_selected(self, filenames):
         """Set the selected files
@@ -84,7 +90,14 @@ class RawData(QGroupBox):
 
         selected = {os.path.basename(f) for f in filenames}
 
+        self.inhibit_selection = True
         for i in range(self.files.count()):
             item = self.files.item(i)
             if item.text() in selected:
                 item.setSelected(True)
+        self.inhibit_selection = False
+
+    def manual_selection(self):
+        """Return True if the user has manually selected files"""
+        if not self.inhibit_selection:
+            self.selected_list_from_oncat = None

--- a/src/shiver/views/data.py
+++ b/src/shiver/views/data.py
@@ -41,8 +41,6 @@ class RawData(QGroupBox):
         self.files = QListWidget()
         self.files.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.files.setSortingEnabled(True)
-        # connect selection change to manual_selection
-        self.files.itemSelectionChanged.connect(self.manual_selection)
 
         layout = QVBoxLayout()
         layout.addWidget(path_line)
@@ -50,7 +48,6 @@ class RawData(QGroupBox):
         self.setLayout(layout)
 
         self.selected_list_from_oncat = None
-        self.inhibit_selection = False
 
     def _path_edited(self):
         if self.path.text() != self.directory:
@@ -70,10 +67,10 @@ class RawData(QGroupBox):
         filenames += list(glob.iglob(os.path.join(directory, "*_event.nxs")))
         self.files.addItems([os.path.basename(f) for f in filenames])
 
-    def get_selected(self):
+    def get_selected(self, use_grouped=False):
         """Return a list of the full path of the files selected"""
         # if the selection is from oncat, use the oncat one
-        if self.selected_list_from_oncat:
+        if use_grouped:
             return self.selected_list_from_oncat
 
         # generate a list based on manual selection
@@ -94,18 +91,11 @@ class RawData(QGroupBox):
 
         selected = {os.path.basename(f) for f in filenames}
 
-        self.inhibit_selection = True
         for i in range(self.files.count()):
             item = self.files.item(i)
             if item.text() in selected:
                 item.setSelected(True)
-        self.inhibit_selection = False
 
-    def manual_selection(self):
-        """Return True if the user has manually selected files"""
-        if not self.inhibit_selection:
-            self.selected_list_from_oncat = None
-
-    def as_dict(self):
+    def as_dict(self, use_grouped=False):
         """Return a dictionary of the current state"""
-        return {"filename": self.get_selected()}
+        return {"filename": self.get_selected(use_grouped=use_grouped)}

--- a/src/shiver/views/data.py
+++ b/src/shiver/views/data.py
@@ -41,6 +41,8 @@ class RawData(QGroupBox):
         self.files = QListWidget()
         self.files.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self.files.setSortingEnabled(True)
+        # connect selection change to manual_selection
+        self.files.itemSelectionChanged.connect(self.manual_selection)
 
         layout = QVBoxLayout()
         layout.addWidget(path_line)
@@ -70,10 +72,12 @@ class RawData(QGroupBox):
 
     def get_selected(self):
         """Return a list of the full path of the files selected"""
+        # if the selection is from oncat, use the oncat one
         if self.selected_list_from_oncat:
             return self.selected_list_from_oncat
-        else:
-            return [os.path.join(self.directory, f.text()) for f in self.files.selectedItems()]
+
+        # generate a list based on manual selection
+        return [os.path.join(self.directory, f.text()) for f in self.files.selectedItems()]
 
     def set_selected(self, filenames):
         """Set the selected files
@@ -101,3 +105,7 @@ class RawData(QGroupBox):
         """Return True if the user has manually selected files"""
         if not self.inhibit_selection:
             self.selected_list_from_oncat = None
+
+    def as_dict(self):
+        """Return a dictionary of the current state"""
+        return {"filename": self.get_selected()}

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -87,6 +87,8 @@ class Generate(QWidget):
         if self.oncat_widget.connected_to_oncat:
             suggested_path = self.oncat_widget.get_suggested_path()
             self.raw_data_widget.path.setText(suggested_path)
+            # trigger path edit finished to update the file list
+            self.raw_data_widget.path.editingFinished.emit()
 
     def update_raw_data_widget_selection(self):
         """Update the selection in the raw data widget"""

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -78,6 +78,7 @@ class Generate(QWidget):
         # - update of selected datasets in oncat widget should update the selection
         #   in the raw data widget if oncat is connected.
         self.oncat_widget.dataset.currentTextChanged.connect(self.update_raw_data_widget_selection)
+        self.oncat_widget.angle_target.valueChanged.connect(self.update_raw_data_widget_selection)
         # - change the dataset to "custom" if the selection in the raw data widget
         #   is changed.
         self.raw_data_widget.files.itemSelectionChanged.connect(self.set_dataset_to_custom)
@@ -131,7 +132,11 @@ class Generate(QWidget):
         rst.update(self.mde_type_widget.as_dict())
         # other widgets to be added here
         # data widget
-        rst.update(self.raw_data_widget.as_dict())
+        # check if oncat dataset is set to custom
+        if self.oncat_widget.dataset.currentText() == "custom":
+            rst.update(self.raw_data_widget.as_dict(use_grouped=False))
+        else:
+            rst.update(self.raw_data_widget.as_dict(use_grouped=True))
         # reduction parameters
         rst.update(self.reduction_parameters.get_reduction_params_dict())
         # NOTE: during development, print the dict to the console

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -78,7 +78,9 @@ class Generate(QWidget):
         self.oncat_widget.dataset.currentTextChanged.connect(self.update_raw_data_widget_selection)
         # - change the dataset to "custom" if the selection in the raw data widget
         #   is changed.
-        self.raw_data_widget.files.itemSelectionChanged.connect(self.oncat_widget.set_dataset_to_custom)
+        self.raw_data_widget.files.itemSelectionChanged.connect(self.set_dataset_to_custom)
+
+        self.inhibit_update = False
 
     def update_raw_data_widget_path(self):
         """Update the path in the raw data widget"""
@@ -93,7 +95,14 @@ class Generate(QWidget):
             if suggested_selected_files:
                 # flatten the list and remove duplicates
                 suggested_selected_files = list(itertools.chain(*suggested_selected_files))
+                self.inhibit_update = True
                 self.raw_data_widget.set_selected(suggested_selected_files)
+                self.inhibit_update = False
+
+    def set_dataset_to_custom(self):
+        """Set the dataset in the oncat widget to "custom"."""
+        if not self.inhibit_update:
+            self.oncat_widget.set_dataset_to_custom()
 
     def _update_title(self, mde_name: str):
         """Update the title of the widget to include the MDE name"""

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -17,6 +17,7 @@ from qtpy.QtWidgets import (
 )
 from qtpy.QtCore import Signal
 from .data import RawData
+from .oncat import Oncat
 
 
 class Generate(QWidget):
@@ -107,14 +108,6 @@ class Generate(QWidget):
         error = QErrorMessage(self)
         error.showMessage(msg)
         error.exec_()
-
-
-class Oncat(QGroupBox):
-    """ONCat widget"""
-
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self.setTitle("Oncat")
 
 
 class MDEType(QGroupBox):

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -95,6 +95,8 @@ class Generate(QWidget):
         if self.oncat_widget.connected_to_oncat:
             suggested_selected_files = self.oncat_widget.get_suggested_selected_files()
             if suggested_selected_files:
+                # cache the list grouping from oncat
+                self.raw_data_widget.selected_list_from_oncat = suggested_selected_files
                 # flatten the list and remove duplicates
                 suggested_selected_files = list(itertools.chain(*suggested_selected_files))
                 self.inhibit_update = True

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -39,7 +39,9 @@ class Generate(QWidget):
         layout.addWidget(RawData(self), 1, 1)
 
         # Oncat widget
-        layout.addWidget(Oncat(self), 2, 1)
+        self.oncat_widget = Oncat(self)
+        layout.addWidget(self.oncat_widget, 2, 1)
+        self.oncat_widget.connect_error_callback(self.show_error_message)
 
         # MDE type widget
         self.mde_type_widget = MDEType(self)

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -344,7 +344,7 @@ class Buttons(QWidget):
         layout = QVBoxLayout()
         self.generate_btn = QPushButton("Generate")
         layout.addWidget(self.generate_btn)
-        self.save_btn = QPushButton("Save settings")
+        self.save_btn = QPushButton("Save configuration")
         layout.addWidget(self.save_btn)
         layout.addStretch()
         self.setLayout(layout)

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -130,6 +130,8 @@ class Generate(QWidget):
         # add diction content from MDE type widget
         rst.update(self.mde_type_widget.as_dict())
         # other widgets to be added here
+        # data widget
+        rst.update(self.raw_data_widget.as_dict())
         # reduction parameters
         rst.update(self.reduction_parameters.get_reduction_params_dict())
         # NOTE: during development, print the dict to the console

--- a/src/shiver/views/oncat.py
+++ b/src/shiver/views/oncat.py
@@ -80,14 +80,6 @@ class OnCatAgent:
         """
         self._agent.login(username, password)
 
-    def connect_cmd(self):
-        """Connect to OnCat with command line interface."""
-        # prompt for username and password
-        username = input("Username: ")
-        password = input("Password: ")
-        # login
-        self.login(username, password)
-
     @property
     def has_token(self):
         """Check if token exists"""

--- a/src/shiver/views/oncat.py
+++ b/src/shiver/views/oncat.py
@@ -172,12 +172,12 @@ class OnCatLogin(QDialog):
         layout.addWidget(label2, 1, 0)
         layout.addWidget(self.user_pwd, 1, 1)
         self.user_pwd.setEchoMode(QLineEdit.Password)
-        button_login = QPushButton("Login")
-        layout.addWidget(button_login, 2, 0, 2, 2)
+        self.button_login = QPushButton("Login")
+        layout.addWidget(self.button_login, 2, 0, 2, 2)
         self.setLayout(layout)
 
         # connect signals and slots
-        button_login.clicked.connect(self.accept)
+        self.button_login.clicked.connect(self.accept)
 
         self.error_message_callback = error_message_callback
 

--- a/src/shiver/views/oncat.py
+++ b/src/shiver/views/oncat.py
@@ -526,12 +526,15 @@ def get_dataset_names(
     datasets = get_data_from_oncat(login, projection, ipts_number, instrument, facility)
 
     if use_notes:
-        dsn = [datasets[i]["metadata"]["entry"]["notes"] for i in range(len(datasets))]
+        dsn = [datasets[i]["metadata"]["entry"].get("notes", None) for i in range(len(datasets))]
     else:
         dsn = [
-            datasets[i]["metadata"]["entry"].get("daslogs", {}).get("sequencename", {}).get("value", "")
+            datasets[i]["metadata"]["entry"].get("daslogs", {}).get("sequencename", {}).get("value", None)
             for i in range(len(datasets))
         ]
+
+    # remove None values
+    dsn = [ds for ds in dsn if ds is not None]
 
     # deal with more than one sequence name
     dsn = [ds if isinstance(ds, str) else ds[-1] for ds in dsn]
@@ -618,7 +621,7 @@ def get_dataset_info(  # pylint: disable=too-many-branches
             datafile["metadata"]["entry"].get("daslogs", {}).get(angle_pv, {}).get("average_value", np.NaN)
         )
         if use_notes:
-            sid = datafile["metadata"]["entry"]["notes"]
+            sid = datafile["metadata"]["entry"].get("notes", None)
         else:
             sid = datafile["metadata"]["entry"].get("daslogs", {}).get("sequencename", {}).get("value", np.NaN)
         if isinstance(sid, list):

--- a/src/shiver/views/oncat.py
+++ b/src/shiver/views/oncat.py
@@ -1,0 +1,98 @@
+"""PyQt widget for the OnCat widget in General tab."""
+from qtpy.QtWidgets import (
+    QGridLayout,
+    QGroupBox,
+    QPushButton,
+    QLabel,
+    QComboBox,
+)
+
+
+class Oncat(QGroupBox):
+    """ONCat widget"""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setTitle("Oncat options")
+
+        # layout for options
+        self.oncat_options_layout = QGridLayout()
+        # dropdown list for instrument
+        self.instrument_label = QLabel("Instrument")
+        self.instrument = QComboBox()
+        self.instrument_items = ["HYSPEC"]
+        self.instrument.addItems(self.instrument_items)
+        self.oncat_options_layout.addWidget(self.instrument_label, 0, 0)
+        self.oncat_options_layout.addWidget(self.instrument, 0, 1)
+        # dropdown list for IPTS
+        self.ipts_label = QLabel("IPTS")
+        self.ipts = QComboBox()
+        self.ipts_items = ["IPTS-12345"]
+        self.ipts.addItems(self.ipts_items)
+        self.oncat_options_layout.addWidget(self.ipts_label, 1, 0)
+        self.oncat_options_layout.addWidget(self.ipts, 1, 1)
+        # dropdown list for dataset
+        self.dataset_label = QLabel("Select dataset")
+        self.dataset = QComboBox()
+        self.dataset_items = ["temperature_2"]
+        self.dataset.addItems(self.dataset_items)
+        self.oncat_options_layout.addWidget(self.dataset_label, 2, 0)
+        self.oncat_options_layout.addWidget(self.dataset, 2, 1)
+        # dropdown list for angle integration target
+        self.angle_target_label = QLabel("Angle integra")
+        self.angle_target = QComboBox()
+        self.angle_target_items = ["None", "temperature_1", "temperature_2"]
+        self.angle_target.addItems(self.angle_target_items)
+        self.oncat_options_layout.addWidget(self.angle_target_label, 3, 0)
+        self.oncat_options_layout.addWidget(self.angle_target, 3, 1)
+
+        # help button
+        self.help_button = QPushButton("Help")
+        self.help_button.setFixedWidth(100)
+        self.help_button.setToolTip("Help")
+        self.help_button.setShortcut("F1")
+        self.oncat_options_layout.addWidget(self.help_button, 4, 0)
+
+        # connect to OnCat button
+        self.oncat_button = QPushButton("&Connect to OnCat")
+        self.oncat_button.setFixedWidth(300)
+        self.oncat_button.setToolTip("Connect to OnCat (requires login credentials)")
+        self.oncat_options_layout.addWidget(self.oncat_button, 4, 1)
+
+        # set layout
+        self.setLayout(self.oncat_options_layout)
+
+        # connect signals and slots
+        self.help_button.clicked.connect(self.help)
+        self.oncat_button.clicked.connect(self.connect_to_oncat)
+
+        # error message callback
+        self.error_message = None
+
+    def connect_to_oncat(self):
+        """Connect to OnCat"""
+        print("Connect to OnCat")
+
+    def help(self):
+        """Help"""
+        print("Help")
+
+    def connect_error_callback(self, callback):
+        """Connect error message callback"""
+        self.error_message = callback
+
+    def as_dict(self) -> dict:
+        """Return widget state as dictionary"""
+        return {
+            "instrument": self.instrument.currentText(),
+            "ipts": self.ipts.currentText(),
+            "dataset": self.dataset.currentText(),
+            "angle_target": self.angle_target.currentText(),
+        }
+    
+    def populate_from_dict(self, state: dict):
+        """Populate widget from dictionary"""
+        self.instrument.setCurrentText(state["instrument"])
+        self.ipts.setCurrentText(state["ipts"])
+        self.dataset.setCurrentText(state["dataset"])
+        self.angle_target.setCurrentText(state["angle_target"])

--- a/src/shiver/views/oncat.py
+++ b/src/shiver/views/oncat.py
@@ -1,11 +1,193 @@
 """PyQt widget for the OnCat widget in General tab."""
+import os
+import json
+import numpy as np
+import pyoncat
 from qtpy.QtWidgets import (
     QGridLayout,
     QGroupBox,
     QPushButton,
     QLabel,
     QComboBox,
+    QDialog,
+    QLineEdit,
+    QDoubleSpinBox,
 )
+from qtpy.QtCore import QTimer
+
+# CONSTANTS
+# NOTE: the client ID is unique for Shiver
+ONCAT_URL = "https://oncat.ornl.gov"
+CLIENT_ID = "99025bb3-ce06-4f4b-bcf2-36ebf925cd1d"
+
+
+class OncatToken:
+    """Class to hold OnCat token"""
+
+    def __init__(self, token_path: str):
+        self.token_path = token_path
+
+    def read_token(self):
+        """Read token from file"""
+        # If there is not a token stored, return
+        # None from the callback.
+        if not os.path.exists(self.token_path):
+            return None
+
+        with open(self.token_path, encoding="UTF-8") as storage:
+            return json.load(storage)
+
+    def write_token(self, token):
+        """Write token to file"""
+        # check if directory exists
+        if not os.path.exists(os.path.dirname(self.token_path)):
+            os.makedirs(os.path.dirname(self.token_path))
+        # write token to file
+        with open(self.token_path, "w", encoding="UTF-8") as storage:
+            json.dump(token, storage)
+        # change permissions to read-only by user
+        os.chmod(self.token_path, 0o600)
+
+
+class OnCatAgent:
+    """Agent to interface with OnCat"""
+
+    def __init__(self) -> None:
+        """Initialize OnCat agent"""
+        user_home_dir = os.path.expanduser("~")
+        self._token = OncatToken(
+            os.path.abspath(f"{user_home_dir}/.shiver/oncat_token.json"),
+        )
+        self._agent = pyoncat.ONCat(
+            ONCAT_URL,
+            client_id=CLIENT_ID,
+            # Pass in token getter/setter callbacks here:
+            token_getter=self._token.read_token,
+            token_setter=self._token.write_token,
+            flow=pyoncat.RESOURCE_OWNER_CREDENTIALS_FLOW,
+        )
+
+    def login(self, username: str, password: str):
+        """Connect to OnCat with given username and password.
+
+        Parameters
+        ----------
+        username : str
+            Username for OnCat
+        password : str
+            Password for OnCat
+        """
+        self._agent.login(username, password)
+
+    def connect_cmd(self):
+        """Connect to OnCat with command line interface."""
+        # prompt for username and password
+        username = input("Username: ")
+        password = input("Password: ")
+        # login
+        self.login(username, password)
+
+    @property
+    def has_token(self):
+        """Check if token exists"""
+        return self._token.read_token() is not None
+
+    @property
+    def is_connected(self):
+        """Check if connected to OnCat"""
+        try:
+            self._agent.Facility.list()  # pylint: disable=no-member
+            return True
+        except pyoncat.InvalidRefreshTokenError:
+            return False
+        except pyoncat.LoginRequiredError:
+            return False
+
+    def get_ipts(self, facility: str, instrument: str) -> list:
+        """Get IPTS numbers for given facility and instrument.
+
+        Parameters
+        ----------
+        facility : str
+            Facility name
+        instrument : str
+            Instrument name
+
+        Returns
+        -------
+        list
+            List of IPTS numbers in string format (IPTS-XXXXX)
+        """
+        # return empty list if not connected
+        if not self.is_connected:
+            return []
+        # get list of experiments
+        experiments = self._agent.Experiment.list(  # pylint: disable=no-member
+            facility=facility,
+            instrument=instrument,
+            projection=["facility", "instrument"],
+        )
+        return list({exp["id"] for exp in experiments})
+
+    def get_datasets(self, facility: str, instrument: str, ipts: int) -> list:
+        """Get datasets for given facility, instrument, and IPTS.
+
+        Parameters
+        ----------
+        facility : str
+            Facility name
+        instrument : str
+            Instrument name
+        ipts : int
+            IPTS number
+
+        Returns
+        -------
+        list
+            List of datasets
+        """
+        # return empty list if not connected
+        if not self.is_connected:
+            return []
+        # get list of datasets
+        return get_dataset_names(
+            self._agent,
+            ipts_number=ipts,
+            instrument=instrument,
+            facility=facility,
+        )
+
+
+class OnCatLogin(QDialog):
+    """OnCat login dialog"""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Use U/XCAM to connect to OnCat")
+        self.resize(350, 200)
+        layout = QGridLayout()
+        label1 = QLabel("UserId")
+        self.user_obj = QLineEdit()
+        layout.addWidget(label1, 0, 0)
+        layout.addWidget(self.user_obj, 0, 1)
+        label2 = QLabel("Password")
+        self.user_pwd = QLineEdit()
+        layout.addWidget(label2, 1, 0)
+        layout.addWidget(self.user_pwd, 1, 1)
+        self.user_pwd.setEchoMode(QLineEdit.Password)
+        button_login = QPushButton("Login")
+        layout.addWidget(button_login, 2, 0, 2, 2)
+        self.setLayout(layout)
+
+        # connect signals and slots
+        button_login.clicked.connect(self.accept)
+
+    def accept(self):
+        """Accept"""
+        # login to OnCat
+        self.parent().oncat_agent.login(self.user_obj.text(), self.user_pwd.text())
+        # close dialog
+        self.close()
 
 
 class Oncat(QGroupBox):
@@ -13,45 +195,44 @@ class Oncat(QGroupBox):
 
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setTitle("Oncat options")
 
         # layout for options
+        self.setTitle("OnCat")
         self.oncat_options_layout = QGridLayout()
         # dropdown list for instrument
         self.instrument_label = QLabel("Instrument")
         self.instrument = QComboBox()
-        self.instrument_items = ["HYSPEC"]
+        self.instrument_items = ["ARCS", "CNCS", "HYSPEC", "SEQUOIA"]
         self.instrument.addItems(self.instrument_items)
         self.oncat_options_layout.addWidget(self.instrument_label, 0, 0)
         self.oncat_options_layout.addWidget(self.instrument, 0, 1)
         # dropdown list for IPTS
         self.ipts_label = QLabel("IPTS")
         self.ipts = QComboBox()
-        self.ipts_items = ["IPTS-12345"]
+        self.ipts_items = []
         self.ipts.addItems(self.ipts_items)
         self.oncat_options_layout.addWidget(self.ipts_label, 1, 0)
         self.oncat_options_layout.addWidget(self.ipts, 1, 1)
         # dropdown list for dataset
         self.dataset_label = QLabel("Select dataset")
         self.dataset = QComboBox()
-        self.dataset_items = ["temperature_2"]
+        self.dataset_items = ["custom"]
         self.dataset.addItems(self.dataset_items)
         self.oncat_options_layout.addWidget(self.dataset_label, 2, 0)
         self.oncat_options_layout.addWidget(self.dataset, 2, 1)
         # dropdown list for angle integration target
-        self.angle_target_label = QLabel("Angle integra")
-        self.angle_target = QComboBox()
-        self.angle_target_items = ["None", "temperature_1", "temperature_2"]
-        self.angle_target.addItems(self.angle_target_items)
+        self.angle_target_label = QLabel("Angle integration step")
+        self.angle_target = QDoubleSpinBox()
+        # set minimum value to 1e-6
+        self.angle_target.setMinimum(1e-6)
+        # default to 1: 1 degree
+        self.angle_target.setValue(1.0)
         self.oncat_options_layout.addWidget(self.angle_target_label, 3, 0)
         self.oncat_options_layout.addWidget(self.angle_target, 3, 1)
 
-        # help button
-        self.help_button = QPushButton("Help")
-        self.help_button.setFixedWidth(100)
-        self.help_button.setToolTip("Help")
-        self.help_button.setShortcut("F1")
-        self.oncat_options_layout.addWidget(self.help_button, 4, 0)
+        # status indicator (disconnected: red, connected: green)
+        self.status_label = QLabel("")
+        self.oncat_options_layout.addWidget(self.status_label, 4, 0)
 
         # connect to OnCat button
         self.oncat_button = QPushButton("&Connect to OnCat")
@@ -63,23 +244,74 @@ class Oncat(QGroupBox):
         self.setLayout(self.oncat_options_layout)
 
         # connect signals and slots
-        self.help_button.clicked.connect(self.help)
         self.oncat_button.clicked.connect(self.connect_to_oncat)
 
         # error message callback
-        self.error_message = None
+        self.error_message_callback = None
+
+        # OnCat agent
+        self.oncat_agent = OnCatAgent()
+
+        # Sync with remote
+        self.sync_with_remote()
+
+        # Sync with remote every 60 seconds
+        # NOTE: make the refresh interval configurable
+        #       in application settings
+        self.update_connection_status_timer = QTimer()
+        self.update_connection_status_timer.timeout.connect(
+            self.sync_with_remote,
+        )
+        self.update_connection_status_timer.start(60_000)
+
+        # change in instrument should trigger update of
+        # - IPTS
+        # - dataset
+        self.instrument.currentTextChanged.connect(self.update_ipts)
+        self.instrument.currentTextChanged.connect(self.update_datasets)
+
+        # change in IPTS should trigger update of
+        # - dataset
+        self.ipts.currentTextChanged.connect(self.update_datasets)
 
     def connect_to_oncat(self):
         """Connect to OnCat"""
-        print("Connect to OnCat")
+        # check if connection exists
+        if self.oncat_agent.is_connected:
+            return
 
-    def help(self):
-        """Help"""
-        print("Help")
+        # check if token exists
+        if self.oncat_agent.has_token:
+            if self.error_message_callback:
+                self.error_message_callback("Session expired. Please login again.")
+
+        # prompt for username and password
+        oncat_login = OnCatLogin(self)
+        oncat_login.show()
+
+        # update connection status
+        self.sync_with_remote()
+
+    def sync_with_remote(self):
+        """Update all items within OnCat widget."""
+        self.update_connection_status()
+
+        # perform list sync only if connected
+        if self.oncat_agent.is_connected:
+            self.update_ipts()
+
+    def update_connection_status(self):
+        """Update connection status"""
+        if self.oncat_agent.is_connected:
+            self.status_label.setText("OnCat: Connected")
+            self.status_label.setStyleSheet("color: green")
+        else:
+            self.status_label.setText("OnCat: Disconnected")
+            self.status_label.setStyleSheet("color: red")
 
     def connect_error_callback(self, callback):
         """Connect error message callback"""
-        self.error_message = callback
+        self.error_message_callback = callback
 
     def as_dict(self) -> dict:
         """Return widget state as dictionary"""
@@ -89,10 +321,303 @@ class Oncat(QGroupBox):
             "dataset": self.dataset.currentText(),
             "angle_target": self.angle_target.currentText(),
         }
-    
+
     def populate_from_dict(self, state: dict):
         """Populate widget from dictionary"""
         self.instrument.setCurrentText(state["instrument"])
         self.ipts.setCurrentText(state["ipts"])
         self.dataset.setCurrentText(state["dataset"])
         self.angle_target.setCurrentText(state["angle_target"])
+
+    def get_angle_integration(self):
+        """Get angle integration target"""
+        return self.angle_target.value()
+
+    def get_dataset(self):
+        """Get dataset"""
+        return self.dataset.currentText()
+
+    def get_ipts(self):
+        """Get IPTS"""
+        return self.ipts.currentText()
+
+    def get_ipts_number(self):
+        """Get IPTS number"""
+        if self.get_ipts() == "":
+            return None
+
+        return int(self.get_ipts().split("-")[1])
+
+    def get_instrument(self):
+        """Get instrument"""
+        instrument = self.instrument.currentText()
+        # NOTE: HYSEPC is stored as HYS on OnCat
+        if instrument == "HYSPEC":
+            instrument = "HYS"
+        # NOTE: SEQUOIA is stored as SEQ on OnCat
+        if instrument == "SEQUOIA":
+            instrument = "SEQ"
+        return instrument
+
+    def get_facility(self):
+        """Get facility based on instrument"""
+        return {"ARCS": "SNS", "CNCS": "SNS", "HYS": "SNS", "SEQ": "SNS"}[self.get_instrument()]
+
+    def update_ipts(self):
+        """Update IPTS list"""
+        # get IPTS list from OnCat
+        ipts_list = self.oncat_agent.get_ipts(
+            self.get_facility(),
+            self.get_instrument(),
+        )
+        # update IPTS list
+        self.ipts.clear()
+        self.ipts.addItems(ipts_list)
+
+    def update_datasets(self):
+        """Update dataset list"""
+        # get dataset list from OnCat
+        dataset_list = ["custom"] + self.oncat_agent.get_datasets(
+            self.get_facility(),
+            self.get_instrument(),
+            self.get_ipts_number(),
+        )
+        # update dataset list
+        self.dataset.clear()
+        self.dataset.addItems(dataset_list)
+
+
+# The following are utility functions migrated from the original
+# oncat_util.py
+def get_data_from_oncat(
+    login: pyoncat.ONCat,
+    projection: list,
+    ipts_number: int,
+    instrument: str,
+    facility: str = "SNS",
+    tags: str = "type/raw",
+) -> dict:
+    """
+    Get data according to a projection from oncat
+
+    Parameters:
+    -----------
+    login : pyoncat.ONCat
+        An object that contains login information to oncat database.
+    projection : list
+        A list of paths in the oncat datafile to extract the relevant information.
+    ipts_number : int,str
+        The experiment identifier number (IPTS)
+    instrument : str
+        The instrument associated with the datafiles
+    facility : str, optional
+        The facility associated with the datafiles (Default = 'SNS')
+    tags : str, optional
+        The type of files to look for in the OnCat database (Default = 'type/raw')
+
+    Returns:
+    --------
+    datafiles: dict
+        A dictionary containing information requested from the OnCat database
+    """
+    datafiles = login.Datafile.list(
+        facility=facility,
+        instrument=instrument,
+        experiment=f"IPTS-{ipts_number}",
+        projection=projection,
+        tags=tags,
+    )
+    return datafiles
+
+
+def get_dataset_names(
+    login: pyoncat.ONCat,
+    ipts_number: int,
+    instrument: str,
+    use_notes: bool = False,
+    facility: str = "SNS",
+) -> list:
+    """
+    A function to return the names of the datasets, either from sequence names or from comments
+
+    Parameters:
+    -----------
+    login : pyoncat.ONCat
+        An object that contains login information to oncat database.
+    ipts_number : int,str
+        The experiment identifier number (IPTS)
+    instrument : str
+        The instrument associated with the datafiles
+    use_notes : bool, optional
+        A flag to indicate that the names of the datasets are stored in the
+        Notes/Comments (as opposed to sequence name)
+    facility : str, optional
+        The facility associated with the datafiles (Default = 'SNS')
+
+    Returns:
+    --------
+    dsn: set of strings
+        A set containing strings with the dataset names, as tored in the OnCat database
+    """
+    projection = ["metadata.entry.daslogs.sequencename", "metadata.entry.notes"]
+    datasets = get_data_from_oncat(login, projection, ipts_number, instrument, facility)
+
+    if use_notes:
+        dsn = [datasets[i]["metadata"]["entry"]["notes"] for i in range(len(datasets))]
+    else:
+        dsn = [
+            datasets[i]["metadata"]["entry"]["daslogs"].get("sequencename", {}).get("value", "")
+            for i in range(len(datasets))
+        ]
+
+    # deal with more than one sequence name
+    dsn = [ds if isinstance(ds, str) else ds[-1] for ds in dsn]
+    dsn = list(set(dsn))
+    return dsn
+
+
+def get_dataset_info(  # pylint: disable=too-many-branches
+    *,
+    login,
+    ipts_number,
+    instrument,
+    dataset_name=None,
+    use_notes=False,
+    facility="SNS",
+    group_by_angle=False,
+    angle_pv="omega",
+    angle_bin=0.5,
+    include_runs=None,
+    exclude_runs=None,
+):
+    """
+    A function to return a list of runs in a dataset, optionally grouped by angle.
+    Grouping by angle is from the lowest value, within angle_bin.
+
+    Parameters:
+    -----------
+    login : pyoncat.ONCat
+        An object that contains login information to oncat database.
+    ipts_number : int,str
+        The experiment identifier number (IPTS)
+    instrument : str
+        The instrument associated with the datafiles
+    dataset_name : str, optional
+        The name of a dataset to look for in the database. It can be None.
+    use_notes : bool, optional
+        A flag to indicate that the names of the datasets are stored in the
+        Notes/Comments (as opposed to sequence name)
+    facility : str, optional
+        The facility associated with the datafiles (Default = 'SNS')
+    group_by_angle : bool, optional
+        A flag to indicate if the runs should be grouped by angle
+    angle_pv : str, optional
+        The name of the angle process variable. The value read from this variable
+        will be used for grouping files together.Default is 'omega'
+    angle_bin : float, optional
+        The maximum difference (in degrees) between angles in the same group. Default is 0.5
+    include_runs : array_like, optional
+        A list or array of additional runs to be added to the same dataset. The default is None
+    exclude_runs : array_like, optional
+        A list or array of runs to be excluded from the dataset. The default is None
+
+    Returns:
+    --------
+    file_names : list
+        List of runs in the dataset, or list of list of runs at the same angle
+
+    Raises:
+    -------
+    ValueError
+        If any of the include_runs is not in the OnCat database for this IPTS
+        If any of the include_runs is already in the dataset
+        If any of the exclude_runs is not already accounted for
+        If no runs were found to match the criteria (for example,
+            dataset_name=None and include_runs=None)
+    """
+    # get run number, angle, and sequence names from oncat
+    projection = ["indexed.run_number", f"metadata.entry.daslogs.{angle_pv}"]
+    if use_notes:
+        projection.append("metadata.entry.notes")
+    else:
+        projection.append("metadata.entry.daslogs.sequencename")
+    datafiles = get_data_from_oncat(login, projection, ipts_number, instrument, facility)
+
+    # {"run_num": "locations"}
+    lookup_table = {df["indexed"]["run_number"]: df["location"] for df in datafiles}
+
+    run_number = np.empty(len(datafiles), dtype="int")
+    angle = {}
+    sequence = np.empty(len(datafiles), dtype="U50")
+    for idx, datafile in enumerate(datafiles):
+        run_number[idx] = datafile["indexed"]["run_number"]
+        angle[str(run_number[idx])] = datafile["metadata"]["entry"]["daslogs"][angle_pv]["average_value"]
+        if use_notes:
+            sid = datafile["metadata"]["entry"]["notes"]
+        else:
+            sid = datafile["metadata"]["entry"]["daslogs"]["sequencename"]["value"]
+        if isinstance(sid, list):
+            sid = sid[-1]
+        sequence[idx] = sid
+    if dataset_name:
+        good_runs = run_number[sequence == dataset_name]
+    else:
+        good_runs = np.array([], dtype="int")
+
+    # include runs
+    if include_runs:
+        include_runs = np.array(include_runs)
+        # check if all include_runs are part of this IPTS
+        condition = np.in1d(include_runs, run_number)
+        if not np.all(condition):
+            not_found = include_runs[np.logical_not(condition)]
+            bad_str = ", ".join([str(nf) for nf in not_found])
+            raise ValueError(f"Could not find the following 'include_runs' in this IPTS: {bad_str}")
+        # check if runs already in the good_runs
+        condition = np.in1d(include_runs, good_runs)
+        if np.any(condition):
+            already_there = include_runs[condition]
+            bad_str = ", ".join([str(at) for at in already_there])
+            raise ValueError(f"The following 'include_runs' are already part of the dataset: {bad_str}")
+        good_runs = np.append(good_runs, include_runs)
+
+    # exclude runs
+    if exclude_runs:
+        exclude_runs = np.array(exclude_runs)
+        # check if all the exclude_runs are already selected
+        condition = np.in1d(exclude_runs, good_runs)
+        if not np.all(condition):
+            not_found = exclude_runs[np.logical_not(condition)]
+            bad_str = ", ".join([str(nf) for nf in not_found])
+            raise ValueError(f"The following 'exclude_runs' are not in this dataset: {bad_str}")
+        good_runs = good_runs[np.in1d(good_runs, exclude_runs, invert=True)]
+
+    # no runs found
+    if len(good_runs) == 0:
+        raise ValueError("Could not find any runs matching your criteria")
+
+    # group by angle if desired
+    if group_by_angle:
+        angle_list = [angle[str(r)] for r in good_runs]
+        # sort runs by angle
+        tmp = list(sorted(zip(angle_list, good_runs)))
+        angle_list, good_runs = zip(*tmp)
+        angle_list = np.array(angle_list)
+        good_runs = np.array(good_runs)
+        grouped_runs = []
+        grouped_filenames = []
+        while len(good_runs) > 0:
+            inds = angle_list - angle_list[0] < angle_bin
+            grouped_runs.append(good_runs[inds].tolist())
+            grouped_filenames.append([lookup_table[r] for r in good_runs[inds]])
+
+            good_runs = good_runs[np.logical_not(inds)]
+            angle_list = angle_list[np.logical_not(inds)]
+
+        good_runs = grouped_runs
+        filenames = grouped_filenames
+    else:
+        good_runs = good_runs.tolist()
+        filenames = [lookup_table[r] for r in good_runs]
+
+    return filenames

--- a/src/shiver/views/oncat.py
+++ b/src/shiver/views/oncat.py
@@ -374,7 +374,7 @@ class Oncat(QGroupBox):
             "instrument": self.instrument.currentText(),
             "ipts": self.ipts.currentText(),
             "dataset": self.dataset.currentText(),
-            "angle_target": self.angle_target.currentText(),
+            "angle_target": self.angle_target.value(),
         }
 
     def populate_from_dict(self, state: dict):
@@ -382,7 +382,7 @@ class Oncat(QGroupBox):
         self.instrument.setCurrentText(state["instrument"])
         self.ipts.setCurrentText(state["ipts"])
         self.dataset.setCurrentText(state["dataset"])
-        self.angle_target.setCurrentText(state["angle_target"])
+        self.angle_target.setValue(state["angle_target"])
 
     def get_angle_integration(self):
         """Get angle integration target"""

--- a/tests/views/test_oncat.py
+++ b/tests/views/test_oncat.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+"""Test the views for the ONCat application."""
+import pytest
+import pyoncat
+from shiver.views.oncat import (
+    OncatToken,
+    OnCatAgent,
+    OnCatLogin,
+    Oncat,
+    get_data_from_oncat,
+    get_dataset_names,
+    get_dataset_info,
+)
+
+
+def test_get_data_from_oncat():
+    """Use mock to test get_data_from_oncat."""
+    # make a mock pyoncat agent
+    class MockDataFile:
+        def __init__(self, name):
+            self.name = name
+
+        def list(self, **kwargs):  # pylint: disable=unused-argument
+            return ["a", "b", "c"]
+
+    class MockAgent:
+        def __init__(self):
+            self.Datafile = MockDataFile("datafile")
+
+    agent = MockAgent()
+
+    # test the function
+    assert get_data_from_oncat(
+        agent,
+        "projection",
+        "ipts",
+        "inst",) == ["a", "b", "c"]
+
+
+def test_get_dataset_names(monkeypatch):
+    """Use mock to test get_dataset_names."""
+    # monkeypatch get_data_from_oncat
+    def mock_get_data_from_oncat(*args, **kwargs):  # pylint: disable=unused-argument
+        mock_data = [
+            {"metadata": 
+                {
+                    "entry": {
+                        "notes": "a"
+                        }
+                }
+            },
+            {"metadata": 
+                {
+                    "entry": {
+                        "daslogs": {
+                             "sequencename": {"value": "b"}
+                            }
+                        }
+                }
+            },
+        ]
+        return mock_data
+
+    monkeypatch.setattr("shiver.views.oncat.get_data_from_oncat", mock_get_data_from_oncat)
+
+    # test the function
+    assert get_dataset_names("login", "ipts", "inst", use_notes=True) == ["a"]
+    assert get_dataset_names("login", "ipts", "inst", use_notes=False) == ["b"]
+
+
+def test_get_dataset_info(monkeypatch):
+    """Use mock to test get_dataset_info."""
+    # monkeypatch get_data_from_oncat
+    def mock_get_data_from_oncat(*args, **kwargs):  # pylint: disable=unused-argument
+        mock_data = [
+            {   
+                "location": "/tmp/a",
+                "indexed": {
+                    "run_number": 1,
+                },
+                "metadata": 
+                {
+                    "entry": {
+                        "notes": "a"
+                        }
+                }
+            },
+            {
+                "location": "/tmp/b",
+                "indexed": {
+                    "run_number": 2,
+                },
+                "metadata": 
+                {
+                    "entry": {
+                        "daslogs": {
+                             "sequencename": {"value": "b"},
+                             "omega": {"average": 1.0},
+                            }
+                        }
+                }
+            },
+        ]
+        return mock_data
+
+    monkeypatch.setattr("shiver.views.oncat.get_data_from_oncat", mock_get_data_from_oncat)
+
+    # test the function (legacy format)
+    assert get_dataset_info(
+        login="login",
+        ipts_number="ipts",
+        instrument="inst",
+        dataset_name="a",
+        use_notes=True,
+    ) == ['/tmp/a']
+
+    # test the function (new format)
+    assert get_dataset_info(
+        login="login",
+        ipts_number="ipts",
+        instrument="inst",
+        dataset_name="b",
+        use_notes=False,
+    ) == ['/tmp/b']
+
+
+if __name__ == "__main__":
+    pytest.main(["-v", __file__])

--- a/tests/views/test_oncat.py
+++ b/tests/views/test_oncat.py
@@ -13,6 +13,40 @@ from shiver.views.oncat import (
 )
 
 
+class MockONcat:
+    """Mock Oncat instance for testing"""
+
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+def test_oncat_token(tmp_path):
+    """Test the OncatToken class."""
+    token_path = str(tmp_path / "shiver_test")
+
+    token = OncatToken(token_path)
+
+    # test write
+    token.write_token("test_token")
+
+    # test read
+    assert token.read_token() == "test_token"
+
+
+def test_oncat_agent(monkeypatch):
+    """Test the OnCatAgent class."""
+    pass
+
+
+def test_oncat_login(monkeypatch):
+    """Test the login window"""
+    pass
+
+
+def test_oncat():
+    """Test the Oncat class."""
+    pass
+
+
 def test_get_data_from_oncat():
     """Use mock to test get_data_from_oncat."""
     # make a mock pyoncat agent

--- a/tests/views/test_oncat.py
+++ b/tests/views/test_oncat.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
+# pylint: disable=all
 """Test the views for the ONCat application."""
 import pytest
-import pyoncat
 from shiver.views.oncat import (
     OncatToken,
     OnCatAgent,
@@ -13,11 +13,25 @@ from shiver.views.oncat import (
 )
 
 
+class MockRecord:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    def list(self, *args, **kwargs) -> list:
+        return [{"id": "test_id"}, {"id": "test_id2"}]
+
+
 class MockONcat:
     """Mock Oncat instance for testing"""
 
     def __init__(self, *args, **kwargs) -> None:
+        self.Facility = MockRecord()
+        self.Experiment = MockRecord()
+
+    def login(self, *args, **kwargs) -> None:
+        """Mock login"""
         pass
+
 
 def test_oncat_token(tmp_path):
     """Test the OncatToken class."""
@@ -34,7 +48,28 @@ def test_oncat_token(tmp_path):
 
 def test_oncat_agent(monkeypatch):
     """Test the OnCatAgent class."""
-    pass
+
+    # mockey patch get_dataset_names
+    def mock_get_dataset_names(*args, **kwargs):
+        return ["test1", "test2"]
+
+    monkeypatch.setattr("shiver.views.oncat.get_dataset_names", mock_get_dataset_names)
+
+    # mockey patch class pyoncat.ONCat
+    monkeypatch.setattr("pyoncat.ONCat", MockONcat)
+
+    # test the class
+    agent = OnCatAgent()
+    # test login
+    agent.login("test_login", "test_password")
+    # test is_connected
+    assert agent.is_connected is True
+    # test get_ipts
+    assert agent.get_ipts("facility", "inst") == ["test_id", "test_id2"]
+    # test get_dataset_names
+    assert agent.get_datasets("facility", "inst", 1) == ["test1", "test2"]
+    # test get agent instance
+    assert agent.get_agent_instance() is not None
 
 
 def test_oncat_login(monkeypatch):
@@ -49,12 +84,13 @@ def test_oncat():
 
 def test_get_data_from_oncat():
     """Use mock to test get_data_from_oncat."""
+
     # make a mock pyoncat agent
     class MockDataFile:
         def __init__(self, name):
             self.name = name
 
-        def list(self, **kwargs):  # pylint: disable=unused-argument
+        def list(self, **kwargs):
             return ["a", "b", "c"]
 
     class MockAgent:
@@ -68,30 +104,18 @@ def test_get_data_from_oncat():
         agent,
         "projection",
         "ipts",
-        "inst",) == ["a", "b", "c"]
+        "inst",
+    ) == ["a", "b", "c"]
 
 
 def test_get_dataset_names(monkeypatch):
     """Use mock to test get_dataset_names."""
+
     # monkeypatch get_data_from_oncat
-    def mock_get_data_from_oncat(*args, **kwargs):  # pylint: disable=unused-argument
+    def mock_get_data_from_oncat(*args, **kwargs):
         mock_data = [
-            {"metadata": 
-                {
-                    "entry": {
-                        "notes": "a"
-                        }
-                }
-            },
-            {"metadata": 
-                {
-                    "entry": {
-                        "daslogs": {
-                             "sequencename": {"value": "b"}
-                            }
-                        }
-                }
-            },
+            {"metadata": {"entry": {"notes": "a"}}},
+            {"metadata": {"entry": {"daslogs": {"sequencename": {"value": "b"}}}}},
         ]
         return mock_data
 
@@ -104,35 +128,30 @@ def test_get_dataset_names(monkeypatch):
 
 def test_get_dataset_info(monkeypatch):
     """Use mock to test get_dataset_info."""
+
     # monkeypatch get_data_from_oncat
-    def mock_get_data_from_oncat(*args, **kwargs):  # pylint: disable=unused-argument
+    def mock_get_data_from_oncat(*args, **kwargs):
         mock_data = [
-            {   
+            {
                 "location": "/tmp/a",
                 "indexed": {
                     "run_number": 1,
                 },
-                "metadata": 
-                {
-                    "entry": {
-                        "notes": "a"
-                        }
-                }
+                "metadata": {"entry": {"notes": "a"}},
             },
             {
                 "location": "/tmp/b",
                 "indexed": {
                     "run_number": 2,
                 },
-                "metadata": 
-                {
+                "metadata": {
                     "entry": {
                         "daslogs": {
-                             "sequencename": {"value": "b"},
-                             "omega": {"average": 1.0},
-                            }
+                            "sequencename": {"value": "b"},
+                            "omega": {"average": 1.0},
                         }
-                }
+                    }
+                },
             },
         ]
         return mock_data
@@ -146,7 +165,7 @@ def test_get_dataset_info(monkeypatch):
         instrument="inst",
         dataset_name="a",
         use_notes=True,
-    ) == ['/tmp/a']
+    ) == ["/tmp/a"]
 
     # test the function (new format)
     assert get_dataset_info(
@@ -155,7 +174,7 @@ def test_get_dataset_info(monkeypatch):
         instrument="inst",
         dataset_name="b",
         use_notes=False,
-    ) == ['/tmp/b']
+    ) == ["/tmp/b"]
 
 
 if __name__ == "__main__":

--- a/tests/views/test_oncat.py
+++ b/tests/views/test_oncat.py
@@ -2,6 +2,8 @@
 # pylint: disable=all
 """Test the views for the ONCat application."""
 import pytest
+import pyoncat
+from qtpy.QtWidgets import QGroupBox
 from shiver.views.oncat import (
     OncatToken,
     OnCatAgent,
@@ -10,6 +12,8 @@ from shiver.views.oncat import (
     get_data_from_oncat,
     get_dataset_names,
     get_dataset_info,
+    ONCAT_URL,
+    CLIENT_ID,
 )
 
 
@@ -65,21 +69,169 @@ def test_oncat_agent(monkeypatch):
     # test is_connected
     assert agent.is_connected is True
     # test get_ipts
-    assert agent.get_ipts("facility", "inst") == ["test_id", "test_id2"]
+    assert set(agent.get_ipts("facility", "inst")) == {"test_id2", "test_id"}
     # test get_dataset_names
-    assert agent.get_datasets("facility", "inst", 1) == ["test1", "test2"]
+    assert set(agent.get_datasets("facility", "inst", 1)) == {"test1", "test2"}
     # test get agent instance
     assert agent.get_agent_instance() is not None
 
 
-def test_oncat_login(monkeypatch):
+def test_oncat_login(qtbot):
     """Test the login window"""
-    pass
+
+    # fake oncat agent
+    class FakeOnCatAgent:
+        def __init__(self) -> None:
+            pass
+
+        def login(self, *args, **kwargs) -> None:
+            pass
+
+    class DummyOnCatAgent:
+        def __init__(self) -> None:
+            self._agent = pyoncat.ONCat(
+                ONCAT_URL,
+                client_id=CLIENT_ID,
+                flow=pyoncat.RESOURCE_OWNER_CREDENTIALS_FLOW,
+            )
+
+        def login(self, username: str, password: str) -> None:
+            self._agent.login(username, password)
+
+    # fake parent widget
+    class FakeParent(QGroupBox):
+        def __init__(self, parent=None) -> None:
+            super().__init__(parent)
+            self.oncat_agent = FakeOnCatAgent()
+
+        def sync_with_remote(self, *args, **kwargs):
+            pass
+
+    class DummyParent(QGroupBox):
+        def __init__(self, parent=None) -> None:
+            super().__init__(parent)
+            self.oncat_agent = DummyOnCatAgent()
+
+        def sync_with_remote(self, *args, **kwargs):
+            pass
+
+    err_msgs = []
+
+    def error_message_callback(msg):
+        err_msgs.append(msg)
+
+    # Use Fake ones to test happy path
+    # case: login successfully (based on fake oncat agent)
+    fake_parent = FakeParent()
+    qtbot.addWidget(fake_parent)
+    oncat_login_wgt = OnCatLogin(fake_parent, error_message_callback)
+    qtbot.addWidget(oncat_login_wgt)
+    oncat_login_wgt.show()
+    #
+    oncat_login_wgt.user_obj.setText("test_login")
+    oncat_login_wgt.user_pwd.setText("test_password")
+    oncat_login_wgt.button_login.click()
+    assert len(err_msgs) == 0
+
+    # Use Dummy ones to test unhappy path
+    dummy_parent = DummyParent()
+    qtbot.addWidget(dummy_parent)
+    # case: login without password
+    oncat_login_wgt1 = OnCatLogin(dummy_parent, error_message_callback)
+    qtbot.addWidget(oncat_login_wgt1)
+    #
+    oncat_login_wgt1.user_obj.setText("test_login")
+    oncat_login_wgt1.user_pwd.setText("")
+    oncat_login_wgt1.button_login.click()
+    assert err_msgs[-1] == "A username and/or password was not provided when logging in."
+    #
+    oncat_login_wgt2 = OnCatLogin(dummy_parent, error_message_callback)
+    qtbot.addWidget(oncat_login_wgt2)
+    oncat_login_wgt2.show()
+    # case: login with wrong password
+    oncat_login_wgt2.user_obj.setText("test_login")
+    oncat_login_wgt2.user_pwd.setText("wrong_password")
+    oncat_login_wgt2.button_login.click()
+    assert err_msgs[-1] == "Invalid username or password. Please try again."
 
 
-def test_oncat():
+def test_oncat(monkeypatch, qtbot):
     """Test the Oncat class."""
-    pass
+
+    # mockpatch OnCatAgent
+    class MockOnCatAgent:
+        def __init__(self) -> None:
+            pass
+
+        def login(self, *args, **kwargs) -> None:
+            pass
+
+        @property
+        def is_connected(self) -> bool:
+            return True
+
+        def get_ipts(self, *args, **kwargs) -> list:
+            return ["IPTS-1111", "IPTS-2222"]
+
+        def get_datasets(self, *args, **kwargs) -> list:
+            return ["test_dataset1", "test_dataset2"]
+
+        def get_agent_instance(self):
+            return "test_agent"
+
+        @property
+        def has_token(self):
+            return True
+
+    monkeypatch.setattr("shiver.views.oncat.OnCatAgent", MockOnCatAgent)
+
+    # mock get_dataset_info
+    def mock_get_dataset_info(*args, **kwargs):
+        return ["test_file1"]
+
+    monkeypatch.setattr("shiver.views.oncat.get_dataset_info", mock_get_dataset_info)
+
+    err_msgs = []
+
+    def error_message_callback(msg):
+        err_msgs.append(msg)
+
+    # test
+    oncat = Oncat()
+    oncat.connect_error_callback(error_message_callback)
+    qtbot.addWidget(oncat)
+    oncat.show()
+    # test connect status check
+    assert oncat.connected_to_oncat is True
+    # test get_suggested_path
+    assert oncat.get_suggested_path() == "/SNS/ARCS/IPTS-1111/nexus"
+    # test get_suggested_selected_files
+    # case 1: no suggestion
+    oncat.dataset.setCurrentText("custom")
+    assert oncat.get_suggested_selected_files() == []
+    # case 2: suggestion
+    oncat.dataset.setCurrentText("test_dataset1")
+    assert oncat.get_suggested_selected_files() == ["test_file1"]
+    # test set_dataset_to_custom
+    oncat.set_dataset_to_custom()
+    assert oncat.dataset.currentText() == "custom"
+    # test active connect to oncat
+    oncat.connect_to_oncat()
+    # test as_dict
+    assert oncat.as_dict() == {"angle_target": 0.1, "dataset": "custom", "instrument": "ARCS", "ipts": "IPTS-1111"}
+    # test populate from dict
+    oncat.populate_from_dict({"angle_target": 0.2, "dataset": "custom", "instrument": "HYSPEC", "ipts": "IPTS-1111"})
+    assert oncat.angle_target.value() == 0.2
+    # test get_ipts
+    assert oncat.get_ipts() == "IPTS-1111"
+    # test get_dataset
+    assert oncat.get_dataset() == "custom"
+    # test get_instrument
+    assert oncat.get_instrument() == "HYS"
+    oncat.instrument.setCurrentText("SEQUOIA")
+    assert oncat.get_instrument() == "SEQ"
+    # test get_facility
+    assert oncat.get_facility() == "SNS"
 
 
 def test_get_data_from_oncat():

--- a/tests/views/test_sample_parameters_buttons.py
+++ b/tests/views/test_sample_parameters_buttons.py
@@ -2,6 +2,7 @@
 import os
 import re
 import functools
+import pytest
 
 from qtpy import QtCore, QtWidgets
 
@@ -525,8 +526,53 @@ def test_help_button(qtbot):
     dialog.close()
 
 
+@pytest.mark.skip(reason="This test is not working on Ubuntu_22.04.")
 def test_get_data_sample_after_apply(qtbot):
-    """Test for retrieving all sample parameters after clicking apply"""
+    """Test for retrieving all sample parameters after clicking apply.
+
+    This test is leading to random Fatal Python error:
+    Current thread 0x00007f26f4f12740 (most recent call first):
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pytestqt/qtbot.py", line 669 in keyClicks
+    File "{REPO}/tests/views/test_sample_parameters_buttons.py", line 551 in handle_dialog
+    File "{REPO}/src/shiver/views/sample.py", line 298 in btn_load_submit
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pytestqt/qtbot.py", line 697 in mouseClick
+    File "{REPO}/tests/views/test_sample_parameters_buttons.py", line 562 in test_get_data_sample_after_apply
+    File "{CONDA}/shiver/lib/python3.8/site-packages/_pytest/python.py", line 195 in pytest_pyfunc_call
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
+    File "{CONDA}/shiver/lib/python3.8/site-packages/_pytest/python.py", line 1789 in runtest
+    File "{CONDA}/shiver/lib/python3.8/site-packages/_pytest/runner.py", line 167 in pytest_runtest_call
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
+    File "{CONDA}/shiver/lib/python3.8/site-packages/_pytest/runner.py", line 260 in <lambda>
+    File "{CONDA}/shiver/lib/python3.8/site-packages/_pytest/runner.py", line 339 in from_call
+    File "{CONDA}/shiver/lib/python3.8/site-packages/_pytest/runner.py", line 259 in call_runtest_hook
+    File "{CONDA}/shiver/lib/python3.8/site-packages/_pytest/runner.py", line 220 in call_and_report
+    File "{CONDA}/shiver/lib/python3.8/site-packages/_pytest/runner.py", line 131 in runtestprotocol
+    File "{CONDA}/shiver/lib/python3.8/site-packages/_pytest/runner.py", line 112 in pytest_runtest_protocol
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
+    File "{CONDA}/shiver/lib/python3.8/site-packages/_pytest/main.py", line 349 in pytest_runtestloop
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
+    File "{CONDA}/shiver/lib/python3.8/site-packages/_pytest/main.py", line 324 in _main
+    File "{CONDA}/shiver/lib/python3.8/site-packages/_pytest/main.py", line 270 in wrap_session
+    File "{CONDA}/shiver/lib/python3.8/site-packages/_pytest/main.py", line 317 in pytest_cmdline_main
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pluggy/_callers.py", line 39 in _multicall
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pluggy/_manager.py", line 80 in _hookexec
+    File "{CONDA}/shiver/lib/python3.8/site-packages/pluggy/_hooks.py", line 265 in __call__
+    File "{CONDA}/shiver/lib/python3.8/site-packages/_pytest/config/__init__.py", line 167 in main
+    File "{CONDA}/shiver/lib/python3.8/site-packages/_pytest/config/__init__.py", line 190 in console_main
+    File "{CONDA}/shiver/bin/pytest", line 10 in <module>
+    Aborted
+
+    Most likely due to extensive usage of qtbot mouse clicking on objects retrieved via findChild by type,
+    which does not ensure the correct widget will be found when multiple windows are open.
+    """
 
     # start sample parameters dialog
     completed = False


### PR DESCRIPTION
## Description

This PR introduces the following changes:

- New OnCat widget is added to allow Shiver to retrieve metadata from OnCat.
- Corresponding unit tests.
- Cross widget connection between data selection and OnCat widget.

## Test instructions

- Clone and setup the feature branch as instructed in the description.
- Start the application and go to the generate page
  ![image](https://user-images.githubusercontent.com/5064852/236266954-aec20c63-1bca-4cda-a741-952adac22074.png)
  - first time, the connection status should be in red.  Once logged in, a token will be saved and shiver can used to automatically connect to OnCat within 24h.
- click `connect to Oncat` and type in UCAM
  ![image](https://user-images.githubusercontent.com/5064852/236267057-b84a33a2-1387-4ca5-a99e-aa97edf69244.png)
- now you should be able to navigate between different instrument, ipts and dataset from the oncat widget. If on analysis cluster, the data widget will also be auto updated if files can be found.
  ![image](https://user-images.githubusercontent.com/5064852/236267266-fd0586e1-6e02-4cb6-ab67-198d455f582a.png)

## Known issues
The unit test  `tests/views/test_sample_parameters_buttons.py` leads to fatal Python error when testing locally and is marked as skipped.
The corresponding error messages are added to the docstring of the skipped test.


> IBM item: [Story939](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20%28Change%20Management%29#action=com.ibm.team.workitem.viewWorkItem&id=939)