### PR TITLE
Implement MDE provenance feature for MDE workspace

### DIFF
--- a/src/shiver/models/generate.py
+++ b/src/shiver/models/generate.py
@@ -296,3 +296,30 @@ class SaveMDObserver(AlgorithmObserver):
     def errorHandle(self, msg):  # pylint: disable=invalid-name
         """Call parent upon error of algorithm"""
         self.parent.finish_save_md(obs=self, error=True, msg=msg)
+
+
+def gather_mde_config_dict(workspace_name: str) -> dict:
+    """Generate a config dictionary for given MDE workspace.
+
+    Parameters
+    ----------
+    workspace_name : str
+        Name of the MDE workspace
+
+    Returns
+    -------
+    dict
+        Dictionary containing the config information
+    """
+    config = {}
+
+    if not mtd.doesExist(workspace_name):
+        return config
+
+    print("Collecting MDE config information...")
+    # workspace = mtd[workspace_name]
+
+    # get the config from the workspace
+    print("Will be implemented later...")
+
+    return config

--- a/src/shiver/models/generate.py
+++ b/src/shiver/models/generate.py
@@ -1,4 +1,5 @@
 """Model for the Generate tab"""
+import ast
 from pathlib import Path
 from mantid.api import (  # pylint: disable=no-name-in-module
     AlgorithmManager,
@@ -316,10 +317,20 @@ def gather_mde_config_dict(workspace_name: str) -> dict:
     if not mtd.doesExist(workspace_name):
         return config
 
-    print("Collecting MDE config information...")
-    # workspace = mtd[workspace_name]
+    workspace = mtd[workspace_name]
 
     # get the config from the workspace
-    print("Will be implemented later...")
+    # NOTE: For MDE created with Shiver, there will be a str log entry
+    #       that contains the dictionary that is used to create the MDE.
+    #       For MDE created outside Shiver, an empty dictionary will be
+    #       returned by default.
+    try:
+        config_str = workspace.getExperimentInfo(0).run().getProperty("MDEConfig").value
+    except RuntimeError:
+        config_str = "{}"
+        logger.warning("No MDEConfig property found in the workspace.")
+
+    # convert the config string to a dictionary
+    config.update(ast.literal_eval(config_str))
 
     return config

--- a/src/shiver/models/generate.py
+++ b/src/shiver/models/generate.py
@@ -112,7 +112,6 @@ class GenerateModel:
         filenames = config_dict.get("filename", "")
         type_input = config_dict.get("mde_type", "Data")
         output_workspace = config_dict.get("mde_name", "outws")
-
         self.workspace_name = output_workspace
         self.output_dir = config_dict.get("output_dir", "")
 

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -14,6 +14,8 @@ from mantid.geometry import (
     PointGroupFactory,
 )
 
+from shiver.models.generate import GenerateModel
+
 logger = Logger("SHIVER")
 
 
@@ -92,8 +94,12 @@ class HistogramModel:
                 # check if file exists
                 if not os.path.isfile(mde_file):
                     # call generate-MDE
-                    self.generate_mde()
-                    ws_data = None
+                    # NOTE: we need the new convention here to call generate_mde
+                    config_dict = dataset
+                    config_dict["mde_name"] = mde_name
+                    config_dict["output_dir"] = mde_folder
+                    self.generate_mde(config_dict)
+                    ws_data = mde_name
                 else:
                     self.load(mde_file, "mde")
                     ws_data = mde_name
@@ -108,8 +114,12 @@ class HistogramModel:
                 # check if file exists
                 if not os.path.isfile(mde_file):
                     # call generate-MDE
-                    self.generate_mde()
-                    ws_background = None
+                    # NOTE: we need the new convention here to call generate_mde
+                    config_dict = dataset
+                    config_dict["mde_name"] = bg_name
+                    config_dict["output_dir"] = mde_folder
+                    self.generate_mde(config_dict)
+                    ws_background = bg_name
                 else:
                     self.load(mde_file, "mde")
                     ws_background = bg_name
@@ -130,9 +140,16 @@ class HistogramModel:
 
         return ws_data, ws_background, ws_norm
 
-    def generate_mde(self) -> str:
+    def generate_mde(self, config_dict: dict) -> str:
         """Generate MDE workspace from given parameters dictionary."""
-        logger.error("Not implemented yet.")
+        # make a model of GenerateMDE so that we can use it to call
+        # the algorithm directly
+        generate_mde_model = GenerateModel()
+        # call the algorithm
+        # NOTE: this call will
+        #       - create the workspace in memory
+        #       - save the workspace to file
+        generate_mde_model.generate_mde(config_dict)
 
     def delete(self, ws_name):
         """Delete the workspace"""

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -72,11 +72,22 @@ class HistogramModel:
             Tuple of workspace names for data, background and normalization.
         """
         ws_data, ws_background, ws_norm = None, None, None
+
+        # Figure out convention
+        if "mde_name" in dataset.keys():
+            # new convention
+            mde_name_label = "mde_name"
+            mde_folder_label = "output_dir"
+        else:
+            # old convention
+            mde_name_label = "MdeName"
+            mde_folder_label = "MdeFolder"
+
         # Data & Background
-        mde_name = dataset.get("MdeName", None)
+        mde_name = dataset.get(mde_name_label, None)
         if mde_name is not None:
             if not mtd.doesExist(mde_name):
-                mde_folder = dataset.get("MdeFolder", "")
+                mde_folder = dataset.get(mde_folder_label, "")
                 mde_file = os.path.join(mde_folder, f"{mde_name}.nxs")
                 # check if file exists
                 if not os.path.isfile(mde_file):
@@ -92,7 +103,7 @@ class HistogramModel:
         bg_name = dataset.get("BackgroundMdeName", None)
         if bg_name is not None:
             if not mtd.doesExist(bg_name):
-                mde_folder = dataset.get("MdeFolder", "")
+                mde_folder = dataset.get(mde_folder_label, "")
                 mde_file = os.path.join(mde_folder, f"{bg_name}.nxs")
                 # check if file exists
                 if not os.path.isfile(mde_file):

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -93,13 +93,7 @@ class HistogramModel:
                 mde_file = os.path.join(mde_folder, f"{mde_name}.nxs")
                 # check if file exists
                 if not os.path.isfile(mde_file):
-                    # call generate-MDE
-                    # NOTE: we need the new convention here to call generate_mde
-                    config_dict = dataset
-                    config_dict["mde_name"] = mde_name
-                    config_dict["output_dir"] = mde_folder
-                    self.generate_mde(config_dict)
-                    ws_data = mde_name
+                    ws_data = self.generate_mde(dataset)
                 else:
                     self.load(mde_file, "mde")
                     ws_data = mde_name
@@ -113,13 +107,8 @@ class HistogramModel:
                 mde_file = os.path.join(mde_folder, f"{bg_name}.nxs")
                 # check if file exists
                 if not os.path.isfile(mde_file):
-                    # call generate-MDE
-                    # NOTE: we need the new convention here to call generate_mde
-                    config_dict = dataset
-                    config_dict["mde_name"] = bg_name
-                    config_dict["output_dir"] = mde_folder
-                    self.generate_mde(config_dict)
-                    ws_background = bg_name
+                    # self.generate_mde(dataset), not supported at the moment
+                    ws_background = None
                 else:
                     self.load(mde_file, "mde")
                     ws_background = bg_name
@@ -142,6 +131,12 @@ class HistogramModel:
 
     def generate_mde(self, config_dict: dict) -> str:
         """Generate MDE workspace from given parameters dictionary."""
+        # if old convention, do not proceed
+        if "MdeName" in config_dict.keys():
+            if self.error_callback:
+                self.error_callback("Old convention is not supported.")
+            return None
+
         # make a model of GenerateMDE so that we can use it to call
         # the algorithm directly
         generate_mde_model = GenerateModel()
@@ -150,6 +145,8 @@ class HistogramModel:
         #       - create the workspace in memory
         #       - save the workspace to file
         generate_mde_model.generate_mde(config_dict)
+
+        return config_dict["mde_name"]
 
     def delete(self, ws_name):
         """Delete the workspace"""

--- a/src/shiver/presenters/generate.py
+++ b/src/shiver/presenters/generate.py
@@ -118,6 +118,14 @@ class GeneratePresenter:
         if advanced_options:
             config_dict["AdvancedOptions"] = {k: v for k, v in advanced_options.items() if v is not None}
 
+        sample_parameters = config_dict.get("SampleParameters", {})
+        if sample_parameters:
+            config_dict["SampleParameters"] = {k: v for k, v in sample_parameters.items() if v is not None}
+
+        polarized_options = config_dict.get("PolarizedOptions", {})
+        if polarized_options:
+            config_dict["PolarizedOptions"] = {k: v for k, v in polarized_options.items() if v is not None}
+
         return config_dict
 
 

--- a/src/shiver/presenters/generate.py
+++ b/src/shiver/presenters/generate.py
@@ -95,6 +95,7 @@ class GeneratePresenter:
         config_dict_str = config_dict_str.replace("null", "None")
         config_dict_str = config_dict_str.replace("true", "True")
         config_dict_str = config_dict_str.replace("false", "False")
+        config_dict_str = config_dict_str[:-1] + "\t}"
 
         content = CONFIG_TEMPLATE.replace("DATA_SET_TO_BE_REPLACED", config_dict_str)
 

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -2,6 +2,7 @@
 from qtpy.QtWidgets import QWidget
 from shiver.views.corrections import Corrections
 from shiver.models.corrections import CorrectionsModel
+from shiver.models.generate import gather_mde_config_dict
 
 
 class HistogramPresenter:
@@ -179,7 +180,25 @@ class HistogramPresenter:
 
     def do_provenance(self, workspace_name: str):
         """Called by the view to show provenance"""
-        print(f"This should open the generate tab and fill in details from the selected MDE: {workspace_name}.")
+        # get the MDE config dict
+        config_dict = gather_mde_config_dict(workspace_name)
+
+        # pop up a warning message if the config dict is empty
+        # NOTE: when mde is note generated with Shiver, there will be no config
+        #       dictionary in the workspace log, therefore the provenance will
+        #       not work.
+        if not config_dict:
+            self.error_message(f"No provenance information found in workspace: {workspace_name}.")
+            return
+
+        # switch to the Generate tab
+        self.view.parent().parent().setCurrentIndex(1)
+
+        # get the handle of the current generate tab
+        generate_tab = self.view.parent().parent().currentWidget()
+
+        # populate the Generate tab with the MDE config dict
+        generate_tab.populate_from_dict(config_dict)
 
     def submit_histogram_to_make_slice(self):
         """Submit the histogram to the model"""

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -22,6 +22,7 @@ class HistogramPresenter:
         self.view.connect_save_workspace_to_ascii(self.save_workspace_to_ascii)
         self.view.connect_save_script_workspace(self.save_workspace_history)
         self.view.connect_corrections_tab(self.create_corrections_tab)
+        self.view.connect_do_provenance_callback(self.do_provenance)
         self.model.connect_error_message(self.error_message)
         self.model.connect_makeslice_finish(self.makeslice_finish)
 
@@ -175,6 +176,10 @@ class HistogramPresenter:
             #
             tab_widget.addTab(corrections_tab_view, tab_name)
             tab_widget.setCurrentWidget(corrections_tab_view)
+
+    def do_provenance(self, workspace_name: str):
+        """Called by the view to show provenance"""
+        print(f"This should open the generate tab and fill in details from the selected MDE: {workspace_name}.")
 
     def submit_histogram_to_make_slice(self):
         """Submit the histogram to the model"""

--- a/src/shiver/views/advanced_options.py
+++ b/src/shiver/views/advanced_options.py
@@ -663,6 +663,13 @@ class AdvancedDialog(QDialog):  # pylint: disable=too-many-public-methods
         self.lcutoff_input.setText(params.get("BadPulsesThreshold", ""))
 
         tib_option = params.get("TimeIndepBackgroundWindow", "Default")
+
+        # NOTE: tib_option should not have been set to None, but it seems like
+        #       something is trying to set it to None due to historical reasons,
+        #       and this is a quick fix to avoid unnecessary errors.
+        if tib_option == None:
+            tib_option = ""
+
         if tib_option == "Default":
             self.tib_default.setChecked(True)
         elif tib_option == "":

--- a/src/shiver/views/advanced_options.py
+++ b/src/shiver/views/advanced_options.py
@@ -667,7 +667,7 @@ class AdvancedDialog(QDialog):  # pylint: disable=too-many-public-methods
         # NOTE: tib_option should not have been set to None, but it seems like
         #       something is trying to set it to None due to historical reasons,
         #       and this is a quick fix to avoid unnecessary errors.
-        if tib_option == None:
+        if tib_option is None:
             tib_option = ""
 
         if tib_option == "Default":

--- a/src/shiver/views/advanced_options.py
+++ b/src/shiver/views/advanced_options.py
@@ -653,47 +653,28 @@ class AdvancedDialog(QDialog):  # pylint: disable=too-many-public-methods
     def populate_advanced_options_from_dict(self, params):
         """Populate all fields from dictionary"""
 
-        # check dictionary format
-        expected_keys = [
-            "MaskInputs",
-            "E_min",
-            "E_max",
-            "ApplyFilterBadPulses",
-            "BadPulsesThreshold",
-            "TimeIndepBackgroundWindow",
-            "Goniometer",
-            "AdditionalDimensions",
-        ]
-        for param in expected_keys:
-            if param not in params.keys():
-                self.show_error_message(f"Invalid dinctionary format. Missing: {param}")
-                return
+        self.set_table_values(params.get("MaskInputs", ""))
+        self.emin_input.setText(str(params.get("E_min", "")))
+        self.emax_input.setText(str(params.get("E_max", "")))
 
-        self.set_table_values(params["MaskInputs"])
-        if params["E_min"]:
-            self.emin_input.setText(params["E_min"])
-        if params["E_max"]:
-            self.emax_input.setText(params["E_max"])
+        self.filter_check.setChecked(params.get("ApplyFilterBadPulses", False))
 
-        self.filter_check.setChecked(params["ApplyFilterBadPulses"])
         # in case None is passed, field is ""
-        if params["BadPulsesThreshold"]:
-            self.lcutoff_input.setText(params["BadPulsesThreshold"])
-        else:
-            self.lcutoff_input.setText("")
-        if params["TimeIndepBackgroundWindow"] == "Default":
-            self.tib_default.setChecked(True)
-        elif isinstance(params["TimeIndepBackgroundWindow"], list):
-            tibs = params["TimeIndepBackgroundWindow"]
-            self.tib_yes.setChecked(True)
-            self.tib_min_input.setText(tibs[0])
-            self.tib_max_input.setText(tibs[1])
-            self.tib_update()
-        else:
-            self.tib_no.setChecked(True)
+        self.lcutoff_input.setText(params.get("BadPulsesThreshold", ""))
 
-        self.gonio_input.setText(params["Goniometer"])
-        self.adt_dim_input.setText(params["AdditionalDimensions"])
+        tib_option = params.get("TimeIndepBackgroundWindow", "Default")
+        if tib_option == "Default":
+            self.tib_default.setChecked(True)
+        elif tib_option == "":
+            self.tib_no.setChecked(True)
+        else:
+            self.tib_yes.setChecked(True)
+            tib_min, tib_max = tib_option.split(",")
+            self.tib_min_input.setText(tib_min)
+            self.tib_max_input.setText(tib_max)
+
+        self.gonio_input.setText(params.get("Goniometer", ""))
+        self.adt_dim_input.setText(params.get("AdditionalDimensions", ""))
 
     def btn_apply_submit(self):
         """Check everything is valid and close dialog"""

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -190,6 +190,7 @@ class Generate(QWidget):
         """
         self.mde_type_widget.populate_from_dict(data)
         self.raw_data_widget.populate_from_dict(data)
+        self.reduction_parameters.populate_red_params_from_dict(data)
 
     def show_error_message(self, msg):
         """Will show a error dialog with the given message

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -189,6 +189,7 @@ class Generate(QWidget):
             The data to populate the widgets with.
         """
         self.mde_type_widget.populate_from_dict(data)
+        self.raw_data_widget.populate_from_dict(data)
 
     def show_error_message(self, msg):
         """Will show a error dialog with the given message

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -459,6 +459,10 @@ class MDEType(QGroupBox):
             # this should never happen
             raise RuntimeError("Invalid MDE type found in history.")
 
+        # check the name and path to make sure they are valid
+        self.check_mde_name()
+        self.check_output_dir()
+
         return True
 
     def connect_update_title_callback(self, callback):

--- a/src/shiver/views/histogram.py
+++ b/src/shiver/views/histogram.py
@@ -143,6 +143,16 @@ class Histogram(QWidget):  # pylint: disable=too-many-public-methods
         """connect a function to the creation of a corrections tab"""
         self.input_workspaces.mde_workspaces.create_corrections_tab_callback = callback
 
+    def connect_do_provenance_callback(self, callback):
+        """connect a function to the creation of a corrections tab.
+
+        Parameters
+        ----------
+        callback : function
+            The function to call when the provenance button is clicked.
+        """
+        self.input_workspaces.mde_workspaces.do_provenance_callback = callback
+
     def gather_workspace_data(self) -> str:
         """Return the name of data workspace."""
         return self.input_workspaces.mde_workspaces.data

--- a/src/shiver/views/reduction_parameters.py
+++ b/src/shiver/views/reduction_parameters.py
@@ -218,6 +218,7 @@ class ReductionParameters(QGroupBox):
             "SampleParameters": {},
             "PolarizedOptions": {},
         }
+
         if self.mask_path.text():
             data["MaskingDataFile"] = self.mask_path.text()
 
@@ -233,19 +234,28 @@ class ReductionParameters(QGroupBox):
         data["AdvancedOptions"] = self.dict_advanced
         data["SampleParameters"] = self.dict_sample
         data["PolarizedOptions"] = self.dict_polarized
+
         return data
 
     def populate_red_params_from_dict(self, params):
         """Populate all fields and inner dialogs from dictionary"""
+        if not params:
+            return
+
+        # sanitize the dictionary
+        self.ei_input.setText(str(params.get("Ei", "")))
+        self.t0_input.setText(str(params.get("T0", "")))
+        self.mask_path.setText(str(params.get("MaskingDataFile", "")))
+        self.norm_path.setText(str(params.get("NormalizationDataFile", "")))
+
+        if "AdvancedOptions" in params.keys():
+            params["AdvancedOptions"]["AdditionalDimensions"] = params["AdvancedOptions"].get(
+                "AdditionalDimensions", ""
+            )
+
         self.dict_advanced = params.get("AdvancedOptions", {})
         self.dict_sample = params.get("SampleParameters", {})
         self.dict_polarized = params.get("PolarizedOptions", {})
 
-        if params.get("Ei", None) is not None:
-            self.ei_input.setText(str(params["Ei"]))
-        if params.get("T0", None) is not None:
-            self.t0_input.setText(str(params["T0"]))
-        if params.get("MaskingDataFile", None) is not None:
-            self.mask_path.setText(params["MaskingDataFile"])
-        if params.get("NormalizationDataFile", None) is not None:
-            self.norm_path.setText(params["NormalizationDataFile"])
+        # update polarization label
+        self.polarization_label.setText(self.dict_polarized.get("PolarizationState", "Unpolarized Data"))

--- a/src/shiver/views/reduction_parameters.py
+++ b/src/shiver/views/reduction_parameters.py
@@ -237,21 +237,6 @@ class ReductionParameters(QGroupBox):
 
     def populate_red_params_from_dict(self, params):
         """Populate all fields and inner dialogs from dictionary"""
-        # expected_keys = [
-        #     "MaskingDataFile",
-        #     "NormalizationDataFile",
-        #     "Ei",
-        #     "T0",
-        #     "AdvancedOptions",
-        #     "SampleParameters",
-        #     "PolarizedOptions",
-        # ]
-
-        # for param in expected_keys:
-        #     if param not in params.keys():
-        #         self.show_error_message(f"Invalid dinctionary format. Missing: {param}")
-        #         return
-
         self.dict_advanced = params.get("AdvancedOptions", {})
         self.dict_sample = params.get("SampleParameters", {})
         self.dict_polarized = params.get("PolarizedOptions", {})

--- a/src/shiver/views/reduction_parameters.py
+++ b/src/shiver/views/reduction_parameters.py
@@ -237,30 +237,30 @@ class ReductionParameters(QGroupBox):
 
     def populate_red_params_from_dict(self, params):
         """Populate all fields and inner dialogs from dictionary"""
-        expected_keys = [
-            "MaskingDataFile",
-            "NormalizationDataFile",
-            "Ei",
-            "T0",
-            "AdvancedOptions",
-            "SampleParameters",
-            "PolarizedOptions",
-        ]
+        # expected_keys = [
+        #     "MaskingDataFile",
+        #     "NormalizationDataFile",
+        #     "Ei",
+        #     "T0",
+        #     "AdvancedOptions",
+        #     "SampleParameters",
+        #     "PolarizedOptions",
+        # ]
 
-        for param in expected_keys:
-            if param not in params.keys():
-                self.show_error_message(f"Invalid dinctionary format. Missing: {param}")
-                return
+        # for param in expected_keys:
+        #     if param not in params.keys():
+        #         self.show_error_message(f"Invalid dinctionary format. Missing: {param}")
+        #         return
 
-        self.dict_advanced = params["AdvancedOptions"]
-        self.dict_sample = params["SampleParameters"]
-        self.dict_polarized = params["PolarizedOptions"]
+        self.dict_advanced = params.get("AdvancedOptions", {})
+        self.dict_sample = params.get("SampleParameters", {})
+        self.dict_polarized = params.get("PolarizedOptions", {})
 
-        if params["Ei"] is not None:
+        if params.get("Ei", None) is not None:
             self.ei_input.setText(str(params["Ei"]))
-        if params["T0"] is not None:
+        if params.get("T0", None) is not None:
             self.t0_input.setText(str(params["T0"]))
-        if params["MaskingDataFile"] is not None:
+        if params.get("MaskingDataFile", None) is not None:
             self.mask_path.setText(params["MaskingDataFile"])
-        if params["NormalizationDataFile"] is not None:
+        if params.get("NormalizationDataFile", None) is not None:
             self.norm_path.setText(params["NormalizationDataFile"])

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -196,6 +196,7 @@ class MDEList(ADSList):
         self.rename_workspace_callback = None
         self.delete_workspace_callback = None
         self.create_corrections_tab_callback = None
+        self.do_provenance_callback = None
 
     def initialize_default(self):
         """initialize invalid style color due to absence of data"""
@@ -242,7 +243,8 @@ class MDEList(ADSList):
         menu.addSeparator()
 
         # data properties
-        provenance = QAction("Provenance")  # To be implemented
+        provenance = QAction("Provenance")
+        provenance.triggered.connect(partial(self.do_provenance, selected_ws_name))
 
         sample_parameters = QAction("Set sample parameters")
         sample_parameters.triggered.connect(partial(self.set_sample, selected_ws_name))
@@ -266,6 +268,17 @@ class MDEList(ADSList):
 
         menu.exec_(QCursor.pos())
         menu.setParent(None)  # Allow this QMenu instance to be cleaned up
+
+    def do_provenance(self, workspace_name: str):
+        """Method to open the provenance window
+
+        Parameters
+        ----------
+        workspace_name : str
+            Name of the workspace to open the provenance window for.
+        """
+        if self.do_provenance_callback:
+            self.do_provenance_callback(workspace_name)  # pylint: disable=not-callable
 
     def set_data(self, name):
         """method to set the selected workspace as 'data' and update border color"""

--- a/tests/models/test_generate_model.py
+++ b/tests/models/test_generate_model.py
@@ -3,7 +3,11 @@
 import time
 import os
 import pytest
-from shiver.models.generate import GenerateModel
+from mantid.simpleapi import Load
+from shiver.models.generate import (
+    GenerateModel,
+    gather_mde_config_dict,
+)
 
 
 def test_generate_mde_model(tmpdir):
@@ -42,6 +46,47 @@ def test_generate_mde_model(tmpdir):
     model.generate_mde(config_dict)
     time.sleep(1)  # wait for async thread to finish
     assert len(err_msg) == 0  # no new error message
+
+
+def test_gather_mde_config_dict():
+    """Test the gather_mde_config_dict function."""
+    datafile = os.path.join(os.path.dirname(__file__), "../data/mde", "mde_provenance_test.nxs")
+
+    # Load the datafile
+    Load(Filename=datafile, OutputWorkspace="mde_provenance_test")
+
+    config_dict = gather_mde_config_dict("mde_provenance_test")
+
+    ref_config_dict = {
+        "mde_name": "mde_test",
+        "mde_type": "Data",
+        "AdvancedOptions": {
+            "MaskInputs": [],
+            "E_min": "1",
+            "E_max": "2",
+            "ApplyFilterBadPulses": True,
+            "BadPulsesThreshold": "95",
+            "Goniometer": "",
+        },
+        "SampleParameters": {
+            "a": "1.00000",
+            "b": "1.00000",
+            "c": "1.00000",
+            "alpha": "90.00000",
+            "beta": "90.00000",
+            "gamma": "90.00000",
+            "u": "0.00000,0.00000,1.00000",
+            "v": "1.00000,0.00000,-0.00000",
+        },
+        "PolarizedOptions": {"PolarizationState": "SF_Pz", "FlippingRatio": "1+x", "PSDA": "1", "SampleLog": "x"},
+    }
+
+    assert config_dict["mde_name"] == ref_config_dict["mde_name"]
+    assert config_dict["mde_type"] == ref_config_dict["mde_type"]
+    # NOTE: do not verify output_dir and filename as they are system dependent
+    assert config_dict["AdvancedOptions"] == ref_config_dict["AdvancedOptions"]
+    assert config_dict["SampleParameters"] == ref_config_dict["SampleParameters"]
+    assert config_dict["PolarizedOptions"] == ref_config_dict["PolarizedOptions"]
 
 
 if __name__ == "__main__":

--- a/tests/views/test_advanced_options_inputs.py
+++ b/tests/views/test_advanced_options_inputs.py
@@ -502,8 +502,8 @@ def test_advanced_options_initialization_from_dict_rows():
     assert dialog.emax_input.text() == params["E_max"]
     assert dialog.filter_check.isChecked() is params["ApplyFilterBadPulses"]
     assert dialog.lcutoff_input.text() == params["BadPulsesThreshold"]
-    assert dialog.tib_min_input.text() == params["TimeIndepBackgroundWindow"].split(",")[0]
-    assert dialog.tib_max_input.text() == params["TimeIndepBackgroundWindow"].split(",")[1]
+    assert dialog.tib_min_input.text() == params["TimeIndepBackgroundWindow"].split(",", maxsplit=1)[0]
+    assert dialog.tib_max_input.text() == params["TimeIndepBackgroundWindow"].split(",", maxsplit=1)[1]
 
     assert dialog.gonio_input.text() == params["Goniometer"]
     assert dialog.adt_dim_input.text() == params["AdditionalDimensions"]

--- a/tests/views/test_advanced_options_inputs.py
+++ b/tests/views/test_advanced_options_inputs.py
@@ -485,7 +485,7 @@ def test_advanced_options_initialization_from_dict_rows():
         "E_max": "11.7",
         "ApplyFilterBadPulses": True,
         "BadPulsesThreshold": "80",
-        "TimeIndepBackgroundWindow": ["1", "8"],
+        "TimeIndepBackgroundWindow": "1, 8",
         "Goniometer": "goniom",
         "AdditionalDimensions": "xx,23,45,z,1,3",
     }
@@ -502,14 +502,11 @@ def test_advanced_options_initialization_from_dict_rows():
     assert dialog.emax_input.text() == params["E_max"]
     assert dialog.filter_check.isChecked() is params["ApplyFilterBadPulses"]
     assert dialog.lcutoff_input.text() == params["BadPulsesThreshold"]
-    assert dialog.tib_min_input.text() == params["TimeIndepBackgroundWindow"][0]
-    assert dialog.tib_max_input.text() == params["TimeIndepBackgroundWindow"][1]
+    assert dialog.tib_min_input.text() == params["TimeIndepBackgroundWindow"].split(",")[0]
+    assert dialog.tib_max_input.text() == params["TimeIndepBackgroundWindow"].split(",")[1]
 
     assert dialog.gonio_input.text() == params["Goniometer"]
     assert dialog.adt_dim_input.text() == params["AdditionalDimensions"]
-
-    # assert no error
-    assert len(dialog.invalid_fields) == 0
 
     dialog.close()
 
@@ -559,7 +556,12 @@ def test_advanced_options_initialization_from_dict_e_default():
 
 
 def test_advanced_options_initialization_from_dict_none_default():
-    """Test for initializing all parameters from dict"""
+    """Test for initializing all parameters from dict.
+
+    NOTE:
+    If not specified, the default value for TimeIndepBackgroundWindow should
+    be the string, Default.
+    """
 
     red_parameters = ReductionParameters()
     dialog = AdvancedDialog(red_parameters)
@@ -573,7 +575,6 @@ def test_advanced_options_initialization_from_dict_none_default():
         "E_max": "",
         "ApplyFilterBadPulses": False,
         "BadPulsesThreshold": "",
-        "TimeIndepBackgroundWindow": None,
         "Goniometer": "g1",
         "AdditionalDimensions": "xx,23,45",
     }
@@ -597,31 +598,5 @@ def test_advanced_options_initialization_from_dict_none_default():
 
     # assert no error
     assert len(dialog.invalid_fields) == 0
-
-    dialog.close()
-
-
-def test_advanced_options_initialization_from_dict_invalid():
-    """Test for initializing parameters from invalid dict"""
-
-    red_parameters = ReductionParameters()
-    dialog = AdvancedDialog(red_parameters)
-    dialog.show()
-
-    # an additional row
-    table_data = [{"Bank": "1,5,9", "Tube": "4,5,7", "Pixel": "8-67"}, {"Bank": "2", "Tube": "2", "Pixel": "12"}]
-
-    params = {
-        "MaskInputs": table_data,
-        "A": "",
-        "E_max": "",
-    }
-
-    # This is to handle modal dialog expected error
-    def handle_dialog():
-        dialog.error.done(1)
-
-    QtCore.QTimer.singleShot(500, partial(handle_dialog))
-    dialog.populate_advanced_options_from_dict(params)
 
     dialog.close()

--- a/tests/views/test_reduction_parameters_inputs.py
+++ b/tests/views/test_reduction_parameters_inputs.py
@@ -235,17 +235,17 @@ def test_reduction_parameters_initialization_from_dict_to_dict(qtbot):
     red_params = generate.reduction_parameters
     table_data = [{"Bank": "1,5,9", "Tube": "4,5,7", "Pixel": "8-67"}, {"Bank": "2", "Tube": "2", "Pixel": "12"}]
     parameters = {
-        "MaskingDataFile": None,
-        "NormalizationDataFile": None,
-        "Ei": None,
-        "T0": None,
+        # "MaskingDataFile": None,
+        # "NormalizationDataFile": None,
+        # "Ei": None,
+        # "T0": None,
         "AdvancedOptions": {
             "MaskInputs": table_data,
-            "E_min": None,
-            "E_max": None,
+            # "E_min": None,
+            # "E_max": None,
             "ApplyFilterBadPulses": False,
-            "BadPulsesThreshold": None,
-            "TimeIndepBackgroundWindow": None,
+            # "BadPulsesThreshold": None,
+            # "TimeIndepBackgroundWindow": None,
             "Goniometer": "g1",
             "AdditionalDimensions": "xx,23,45",
         },


### PR DESCRIPTION
Description
---------------

This PR introduces the following changes:

- Context menu of MDE workspace, `provenance` will now automatically populate the generate tab if it is created with Shiver.
- Fix an issue where advanced option settings are not properly cached and restored.
- Implement the `generate_mde` support for the load from script option where Shiver will try to generate the MDE if the file cannot be found on disk.
- Switch most dictionary accessor to use `.get` method for a more permissive approach.

Testing Instructions
-------------------------

- Clone the feature branch and perform editable install following instructions from Readme.
- Create an MDE workspace with some settings.
- Create another MDE workspace with different settings.
- In the main tab, click on the workspace name and select `provenance` should auto populate the generate tab.
- In the generate tab, click save configuration to save a python script, then switch back to main tab and delete all MDE workspace. Use the load script button to load the script just saved, and it should pick up the data on disk and load it directly. Delete all MDE workspace in memory as well as the file on disk, try to load the same script again, it should generate the MDE workspace and save it to disk.
