### PR TITLE
Clean up script generation

### DIFF
--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -258,12 +258,12 @@ class HistogramModel:
             previous_name = alg_name
             separator = ",\n" + comment + "\t"
             alg_props = []
-            for p in alg.getProperties():
-                default = p.isDefault()
-                value = p.value()
+            for prop in alg.getProperties():
+                default = prop.isDefault()
+                value = prop.value()
                 if value and not default:
                     value = value.replace('"', "'")
-                    alg_props.append(f'{p.name()}="{value}"')
+                    alg_props.append(f'{prop.name()}="{value}"')
             alg_props = separator.join(alg_props)
             script.append(f"{comment}{alg_name}({alg_props})")
 

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -42,7 +42,7 @@ class HistogramModel:
         elif ws_type == "norm":
             logger.information(f"Loading {filename} as normalization")
             load = AlgorithmManager.create("LoadNexusProcessed")
-            additional_parameters = {'LoadHistory': False}
+            additional_parameters = {"LoadHistory": False}
         else:
             logger.error(f"Unsupported workspace type {ws_type} for {filename}")
 
@@ -241,27 +241,28 @@ class HistogramModel:
         """Save the mantid algorithm history"""
         history = mtd[ws_name].getHistory()
 
-        script = ["import shiver",
-                  f"from mantid.simpleapi import {', '.join(set(alg.name() for alg in history.getAlgorithmHistories()))}",
-                  "",
-                  "",
-                  ]
+        script = [
+            "import shiver",
+            f"from mantid.simpleapi import {', '.join(set(alg.name() for alg in history.getAlgorithmHistories()))}",
+            "",
+            "",
+        ]
 
-        previous_name = ''
+        previous_name = ""
         for alg in history.getAlgorithmHistories():
             alg_name = alg.name()
-            if alg_name == 'LoadMD' and previous_name == 'GenerateDGSMDE':
-                comment = '# '
+            if alg_name == "LoadMD" and previous_name == "GenerateDGSMDE":
+                comment = "# "
             else:
-                comment = ''
+                comment = ""
             previous_name = alg_name
-            separator = ',\n'+comment +'\t'
+            separator = ",\n" + comment + "\t"
             alg_props = []
             for p in alg.getProperties():
                 default = p.isDefault()
                 value = p.value()
                 if value and not default:
-                    value=value.replace("\"","'")
+                    value = value.replace('"', "'")
                     alg_props.append(f'{p.name()}="{value}"')
             alg_props = separator.join(alg_props)
             script.append(f"{comment}{alg_name}({alg_props})")

--- a/src/shiver/views/loading_buttons.py
+++ b/src/shiver/views/loading_buttons.py
@@ -43,7 +43,6 @@ class LoadingButtons(QWidget):
 
         self.gen_dataset.clicked.connect(self._gen_dataset_click)
 
-
     def _gen_dataset_click(self):
         self.parent().parent().parent().setCurrentIndex(1)
 

--- a/src/shiver/views/loading_buttons.py
+++ b/src/shiver/views/loading_buttons.py
@@ -41,8 +41,11 @@ class LoadingButtons(QWidget):
         self.load_dataset_callback = None
         self.error_msg_callback = None
 
-        # disable generate dataset button (not implemented for phase 1)
-        self.gen_dataset.setEnabled(False)
+        self.gen_dataset.clicked.connect(self._gen_dataset_click)
+
+
+    def _gen_dataset_click(self):
+        self.parent().parent().parent().setCurrentIndex(1)
 
     def _on_load_mde_click(self):
         filename, _ = QFileDialog.getOpenFileName(

--- a/tests/models/test_histogram_saving.py
+++ b/tests/models/test_histogram_saving.py
@@ -35,6 +35,6 @@ def test_saving(tmp_path):
     assert lines[0] == "import shiver\n"
     assert lines[1] == "from mantid.simpleapi import CreateMDHistoWorkspace\n"
     assert (
-        " ".join([l.strip() for l in lines[4:]]) == 'CreateMDHistoWorkspace(SignalInput="2,3", ErrorInput="1,1", '
+        " ".join([line.strip() for line in lines[4:]]) == 'CreateMDHistoWorkspace(SignalInput="2,3", ErrorInput="1,1", '
         'Dimensionality="1", Extents="-2,2", NumberOfBins="2", Names="A", Units="a", OutputWorkspace="test_workspace")'
     )

--- a/tests/models/test_histogram_saving.py
+++ b/tests/models/test_histogram_saving.py
@@ -31,9 +31,10 @@ def test_saving(tmp_path):
     with open(tmp_path / "test_workspace.py", encoding="utf-8") as f_open:
         lines = f_open.readlines()
 
-    assert len(lines) == 2
-    assert lines[0] == "from mantid.simpleapi import CreateMDHistoWorkspace\n"
+    assert len(lines) == 12
+    assert lines[0] == "import shiver\n"
+    assert lines[1] == "from mantid.simpleapi import CreateMDHistoWorkspace\n"
     assert (
-        lines[1] == "CreateMDHistoWorkspace(SignalInput='2,3', ErrorInput='1,1', Dimensionality='1', "
-        "Extents='-2,2', NumberOfBins='2', Names='A', Units='a', OutputWorkspace='test_workspace')"
+        " ".join([l.strip() for l in lines[4:]]) == 'CreateMDHistoWorkspace(SignalInput="2,3", ErrorInput="1,1", '
+        'Dimensionality="1", Extents="-2,2", NumberOfBins="2", Names="A", Units="a", OutputWorkspace="test_workspace")'
     )


### PR DESCRIPTION
The script generated by Shiver now can be run in Mantid. It should look something like
```python
import shiver
from mantid.simpleapi import LoadNexusProcessed, GenerateDGSMDE, MakeSlice, LoadMD


GenerateDGSMDE(Filenames="/home/3y9/Shiver/tests/data/raw/HYS_178923.nxs.h5",
	Type="Background (angle integrated)",
	UBParameters="{}",
	OutputWorkspace="t")
# LoadMD(Filename="/tmp/t.nxs",
# 	OutputWorkspace="t")
GenerateDGSMDE(Filenames="/home/3y9/Shiver/tests/data/raw/HYS_178921.nxs.h5,/home/3y9/Shiver/tests/data/raw/HYS_178922.nxs.h5",
	UBParameters="{}",
	OutputWorkspace="t0")
# LoadMD(Filename="/tmp/t0.nxs",
# 	OutputWorkspace="t0")
LoadNexusProcessed(Filename="/home/3y9/Shiver/tests/data/normalization/TiZr.nxs",
	OutputWorkspace="TiZr",
	LoadHistory="0")
MakeSlice(InputWorkspace="t0",
	BackgroundWorkspace="t",
	NormalizationWorkspace="TiZr",
	Dimension0Binning="0.1",
	Dimension3Name="DeltaE",
	Smoothing="0",
	OutputWorkspace="Histogram_1")

```
Also enabled the Generate dataset button.