### PR TITLE
Move code around so that you can get the version without importing Mantid

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ exclude = ["tests*", "DGS_SC_scripts*"]
 "*" = ["*.yml","*.yaml","*.ini"]
 
 [project.gui-scripts]
-shiver = "shiver:main"
+shiver = "shiver.shiver:gui"
 
 [tool.pylint]
 max-line-length = 120

--- a/src/shiver/__init__.py
+++ b/src/shiver/__init__.py
@@ -2,36 +2,11 @@
 Contains the entry point for the application
 """
 
-import sys
-from qtpy.QtWidgets import QApplication
-
-from mantid.kernel import Logger
-from mantidqt.gui_helper import set_matplotlib_backend
-
-# make sure the algorithms have been loaded so they are available to the AlgorithmManager
-import mantid.simpleapi  # noqa: F401
-
-# Need to import the new algorithms so they are registered with mantid
-import shiver.models.makeslice  # noqa: F401 pylint: disable=unused-import
-import shiver.models.convert_dgs_to_single_mde  # noqa: F401 pylint: disable=unused-import
-import shiver.models.generate_dgs_mde  # noqa: F401 pylint: disable=unused-import
-from .version import __version__
-
-# make sure matplotlib is correctly set before we import shiver
-set_matplotlib_backend()
-
-from .shiver import Shiver  # noqa: E402 pylint: disable=wrong-import-position
-
-logger = Logger("SHIVER")
-
-logger.information(f"Shiver version: {__version__}")
+from .version import __version__  # noqa: F401
 
 
-def main():
-    """
-    Main entry point for Qt application
-    """
-    app = QApplication(sys.argv)
-    window = Shiver()
-    window.show()
-    sys.exit(app.exec_())
+def Shiver():  # pylint: disable=invalid-name
+    """This is needed for backward compatibility because mantid workbench does "from shiver import Shiver" """
+    from .shiver import Shiver as shiver  # pylint: disable=import-outside-toplevel
+
+    return shiver()

--- a/src/shiver/shiver.py
+++ b/src/shiver/shiver.py
@@ -2,10 +2,28 @@
 Main Qt application for shiver
 """
 
-from qtpy.QtWidgets import QMainWindow
-from shiver.configuration import Configuration
-from shiver.version import __version__
-from shiver.views.mainwindow import MainWindow
+import sys
+from qtpy.QtWidgets import QApplication, QMainWindow
+
+from mantid.kernel import Logger
+from mantidqt.gui_helper import set_matplotlib_backend
+
+# make sure matplotlib is correctly set before we import shiver
+set_matplotlib_backend()
+
+# make sure the algorithms have been loaded so they are available to the AlgorithmManager
+import mantid.simpleapi  # noqa: F401, E402 pylint: disable=unused-import, wrong-import-position
+
+# Need to import the new algorithms so they are registered with mantid
+import shiver.models.makeslice  # noqa: F401, E402 pylint: disable=unused-import, wrong-import-position
+import shiver.models.convert_dgs_to_single_mde  # noqa: F401, E402 pylint: disable=unused-import, wrong-import-position
+import shiver.models.generate_dgs_mde  # noqa: F401, E402 pylint: disable=unused-import, wrong-import-position
+
+from shiver.configuration import Configuration  # noqa: E402 pylint: disable=wrong-import-position
+from shiver.version import __version__  # noqa: E402 pylint: disable=wrong-import-position
+from shiver.views.mainwindow import MainWindow  # noqa: E402 pylint: disable=wrong-import-position
+
+logger = Logger("SHIVER")
 
 
 class Shiver(QMainWindow):
@@ -20,6 +38,7 @@ class Shiver(QMainWindow):
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        logger.information(f"Shiver version: {__version__}")
         config = Configuration()
         if not config.is_valid():
             msg = (
@@ -34,3 +53,14 @@ class Shiver(QMainWindow):
         self.setWindowTitle(f"SHIVER - {__version__}")
         self.main_window = MainWindow(self)
         self.setCentralWidget(self.main_window)
+
+
+def gui():
+    """
+    Main entry point for Qt application
+    """
+
+    app = QApplication(sys.argv)
+    window = Shiver()
+    window.show()
+    sys.exit(app.exec_())


### PR DESCRIPTION
You should now be able to run

```python
python -c "from shiver import __version__; print(__version__)"
```

without a bunch of other stuff being printed