### PR TITLE
Made updates to environment.yml. (FOR EWM 2602)

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,25 +1,25 @@
 name: shiver
 channels:
- - conda-forge
- - mantid/label/nightly
- - oncat
+  - conda-forge
+  - mantid/label/nightly
+  - oncat
 dependencies:
- - anaconda-client
- - boa
- - conda-build
- - conda-verify
- - mantidworkbench
- - pre-commit
- - versioningit
- - pylint=2.17.3
- - pytest=7.2.1
- - pytest-qt=4.2.0
- - pytest-cov=4.0.0
- - setuptools
- - sphinx
- - python-build
- - pyoncat
- - pip
- - pip:
-   - sphinx-rtd-theme
-   - check-wheel-contents
+  - anaconda-client
+  - boa
+  - conda-build
+  - conda-verify
+  - check-wheel-contents
+  - mantidworkbench
+  - pre-commit
+  - versioningit
+  - pylint=2.17.3
+  - pytest=7.2.1
+  - pytest-qt=4.2.0
+  - pytest-cov=4.0.0
+  - setuptools
+  - sphinx
+  - sphinx-rtd-theme
+  - python-build
+  - pyoncat
+  - gtk3
+  - libstdcxx-ng


### PR DESCRIPTION
In this PR, the `environment.yml` file was modified to remove pip under the dependencies and also the dependencies that previously employed pip to be pulled. They have now been moved and a few packages have been added in order to address some **errors** that were given by mamba:



![image](https://github.com/neutrons/Shiver/assets/106342815/3b35b1aa-25c5-4a93-a5d0-0fa42199aa20)


According to this, the following packages were added:
- gtk3
- libstdcxx-ng

**For Testing**, the original build environment was deleted and after the modification of the environment.yml file. the environment was re-built and then dependencies installed. Pytest was run with the env activated and as well as the application. All seemed to function correctly other than the errors that were given during the env build step.