### PR TITLE
Polarization dialog - Parameter storage in the workspace

### DIFF
--- a/src/shiver/models/generate.py
+++ b/src/shiver/models/generate.py
@@ -100,10 +100,11 @@ class GenerateModel:
         #         'matrix_ub': '1.00000,0.00000,0.00000,0.00000,1.00000,0.00000,0.00000,-0.00000,1.00000',
         #         },
         #     'PolarizedOptions': {
-        #         'PolarizationState': 'SF_Pz',
+        #         'PolarizationState': 'SF',
+        #         'PolarizationDirection': 'Pz',
         #         'FlippingRatio': '1+x',
         #         'PSDA': '1',
-        #         'SampleLog': 'x',
+        #         'FlippingRatioSampleLog': 'x',
         #         }
         # }
 

--- a/src/shiver/models/generate.py
+++ b/src/shiver/models/generate.py
@@ -5,9 +5,7 @@ from mantid.api import (  # pylint: disable=no-name-in-module
     AlgorithmManager,
     AlgorithmObserver,
 )
-from mantid.simpleapi import (  # pylint: disable=no-name-in-module
-    mtd,
-)
+from mantid.simpleapi import mtd, AddSampleLog  # pylint: disable=no-name-in-module
 from mantid.kernel import (  # pylint: disable=no-name-in-module
     Logger,
     Property,
@@ -208,6 +206,13 @@ class GenerateModel:
             # attach config_dict to the workspace
             workspace = mtd[self.workspace_name]
             workspace.getExperimentInfo(0).mutableRun().addProperty("MDEConfig", str(self.config_dict), True)
+
+            # save polarization sample logs separately
+            if self.config_dict["PolarizedOptions"]:
+                for field, value in self.config_dict["PolarizedOptions"].items():
+                    if field != "PSDA":
+                        AddSampleLog(workspace, LogName=field, LogText=value, LogType="String")
+
             # kick off the saving of the output to disk
             self.save_mde_to_disk()
 

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -284,24 +284,23 @@ class HistogramModel:  # pylint: disable=too-many-public-methods
 
     def save_polarization_state(self, name, pol_state):
         """Save the polarization state as Sample Log in workspace"""
-        workspace = mtd[name]
         # valid pol_states should be: UNP, SF or NSF
         if pol_state in ["UNP", "SF", "NSF"]:
-            AddSampleLog(workspace, LogName="polarization_state", LogText=pol_state, LogType="String")
+            self.save_experiment_sample_log(name, "PolarizationState", pol_state)
         else:
             logger.error("Invalid polarization state")
 
     def get_polarization_state(self, name):
         """Get the polarization state from Sample Log in workspace"""
-        workspace = mtd[name]
-        pol_state = self.get_experiment_sample_log(workspace, "polarization_state")
+        pol_state = self.get_experiment_sample_log(name, "PolarizationState")
         if pol_state is None:
             # revert to default unpolarized state
             pol_state = "UNP"
         return pol_state
 
-    def get_experiment_sample_log(self, workspace, log_name):
+    def get_experiment_sample_log(self, name, log_name):
         """Get the sample log with name"""
+        workspace = mtd[name]
         log_value = None
         if hasattr(workspace, "getExperimentInfo"):
             try:
@@ -314,6 +313,12 @@ class HistogramModel:  # pylint: disable=too-many-public-methods
             except ValueError as err:
                 logger.error(f"Experiment info error {err}.")
         return log_value
+
+    def save_experiment_sample_log(self, name, log_name, log_value):
+        """Add the sample log with log_name and log_value in the workspace with name"""
+
+        workspace = mtd[name]
+        AddSampleLog(workspace, LogName=log_name, LogText=log_value, LogType="String")
 
     def finish_loading(self, obs, filename, ws_type, ws_name, error=False, msg=""):
         """This is the callback from the algorithm observer"""
@@ -426,12 +431,10 @@ class HistogramModel:  # pylint: disable=too-many-public-methods
         """Method to validate sample logs and flipping ratios of SF and NSF workspaces"""
         # find the flipping ratio
         # SpinFlip workspace
-        sf_workspace = mtd[config.get("SFInputWorkspace")]
-        sf_flipping_ratio = self.get_flipping_ratio(sf_workspace)
+        sf_flipping_ratio = self.get_flipping_ratio(config.get("SFInputWorkspace"))
 
         # NonSpinflip workspace
-        nsf_workspace = mtd[config.get("NSFInputWorkspace")]
-        nsf_flipping_ratio = self.get_flipping_ratio(nsf_workspace)
+        nsf_flipping_ratio = self.get_flipping_ratio(config.get("NSFInputWorkspace"))
 
         # compare the flipping ratios of the two workspaces gathered from sample logs
         # depending on the error status and user input
@@ -491,9 +494,8 @@ class HistogramModel:  # pylint: disable=too-many-public-methods
             )
 
             # get the flipping ratio of sf
-            sf_workspace = mtd[config.get("SFInputWorkspace")]
-            flipping_ratio = self.get_experiment_sample_log(sf_workspace, "FlippingRatio")
-            sample_log = self.get_experiment_sample_log(sf_workspace, "FlippingRatioSampleLog")
+            flipping_ratio = self.get_experiment_sample_log(config.get("SFInputWorkspace"), "FlippingRatio")
+            sample_log = self.get_experiment_sample_log(config.get("SFInputWorkspace"), "FlippingRatioSampleLog")
 
             config["FlippingRatio"] = flipping_ratio
             config["FlippingRatioSampleLog"] = ""

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -287,6 +287,9 @@ class HistogramModel:  # pylint: disable=too-many-public-methods
         # valid pol_states should be: UNP, SF or NSF
         if pol_state in ["UNP", "SF", "NSF"]:
             self.save_experiment_sample_log(name, "PolarizationState", pol_state)
+            if pol_state in ["SF", "NSF"]:
+                # add default polarization direction
+                self.save_experiment_sample_log(name, "PolarizationDirection", "Pz")
         else:
             logger.error("Invalid polarization state")
 

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -288,8 +288,10 @@ class HistogramModel:  # pylint: disable=too-many-public-methods
         if pol_state in ["UNP", "SF", "NSF"]:
             self.save_experiment_sample_log(name, "PolarizationState", pol_state)
             if pol_state in ["SF", "NSF"]:
-                # add default polarization direction
-                self.save_experiment_sample_log(name, "PolarizationDirection", "Pz")
+                polarization_direction_log = self.get_experiment_sample_log(name, "PolarizationDirection")
+                if polarization_direction_log is None:
+                    # add default polarization direction if it does not exist
+                    self.save_experiment_sample_log(name, "PolarizationDirection", "Pz")
         else:
             logger.error("Invalid polarization state")
 

--- a/src/shiver/models/makeslices.py
+++ b/src/shiver/models/makeslices.py
@@ -5,6 +5,7 @@ from mantid.api import (
     DataProcessorAlgorithm,
     AlgorithmFactory,
     PropertyMode,
+    Progress,
     mtd,
     IMDEventWorkspaceProperty,
     IMDHistoWorkspaceProperty,
@@ -99,6 +100,9 @@ class MakeSFCorrectedSlices(DataProcessorAlgorithm):
         )
 
     def PyExec(self):
+        endrange = 100
+        progress = Progress(self, start=0.0, end=1.0, nreports=endrange)
+
         flipping_ratio = self.getPropertyValue("FlippingRatio")
 
         var_names = ""
@@ -145,30 +149,37 @@ class MakeSFCorrectedSlices(DataProcessorAlgorithm):
         sf_f, sf_1 = FlippingRatioCorrectionMD(
             InputWorkspace=sf_mde, FlippingRatio=flipping_ratio, SampleLogs=var_names
         )
+        progress.report(int(endrange * 0.05), "FlippingRatioCorrectionMD for SF")
+
         nsf_f, nsf_1 = FlippingRatioCorrectionMD(
             InputWorkspace=nsf_mde, FlippingRatio=flipping_ratio, SampleLogs=var_names
         )
+        progress.report(int(endrange * 0.1), "FlippingRatioCorrectionMD for NSF")
 
         # make slices for each polarized workspace
         # sf_f
         sf_slice_output_f = sf_slice_name + "_F"
         slice_input = sf_f.name()
         MakeSlice(InputWorkspace=slice_input, OutputWorkspace=sf_slice_output_f, **makeslice_parameters)
+        progress.report(int(endrange * 0.3), "MakeSlice SF_F")
 
         # sf_1
         sf_slice_output_1 = sf_slice_name + "_1"
         slice_input = sf_1.name()
         MakeSlice(InputWorkspace=slice_input, OutputWorkspace=sf_slice_output_1, **makeslice_parameters)
+        progress.report(int(endrange * 0.5), "MakeSlice SF_1")
 
         # nsf_f
         nsf_slice_output_f = nsf_slice_name + "_F"
         slice_input = nsf_f.name()
         MakeSlice(InputWorkspace=slice_input, OutputWorkspace=nsf_slice_output_f, **makeslice_parameters)
+        progress.report(int(endrange * 0.7), "MakeSlice NSF_F")
 
         # nsf_1
         nsf_slice_output_1 = nsf_slice_name + "_1"
         slice_input = nsf_1.name()
         MakeSlice(InputWorkspace=slice_input, OutputWorkspace=nsf_slice_output_1, **makeslice_parameters)
+        progress.report(int(endrange * 0.9), "MakeSlice NSF_1")
 
         # workspace calculations
         sf_output = sf_slice_name
@@ -204,6 +215,7 @@ class MakeSFCorrectedSlices(DataProcessorAlgorithm):
                 ]
             )
             raise err
+        progress.report(endrange, "Done")
         Comment(sf_output, f"Shiver version {__version__}")
         Comment(nsf_output, f"Shiver version {__version__}")
 

--- a/src/shiver/models/makeslices.py
+++ b/src/shiver/models/makeslices.py
@@ -5,7 +5,6 @@ from mantid.api import (
     DataProcessorAlgorithm,
     AlgorithmFactory,
     PropertyMode,
-    Progress,
     mtd,
     IMDEventWorkspaceProperty,
     IMDHistoWorkspaceProperty,
@@ -100,9 +99,6 @@ class MakeSFCorrectedSlices(DataProcessorAlgorithm):
         )
 
     def PyExec(self):
-        endrange = 100
-        progress = Progress(self, start=0.0, end=1.0, nreports=endrange)
-
         flipping_ratio = self.getPropertyValue("FlippingRatio")
 
         var_names = ""
@@ -146,40 +142,55 @@ class MakeSFCorrectedSlices(DataProcessorAlgorithm):
             makeslice_parameters[par_name] = self.getProperty(par_name).value
 
         # corrections
-        sf_f, sf_1 = FlippingRatioCorrectionMD(
-            InputWorkspace=sf_mde, FlippingRatio=flipping_ratio, SampleLogs=var_names
-        )
-        progress.report(int(endrange * 0.05), "FlippingRatioCorrectionMD for SF")
+        sf_f, sf_1 = FlippingRatioCorrectionMD(InputWorkspace=sf_mde,
+                                               FlippingRatio=flipping_ratio,
+                                               SampleLogs=var_names,
+                                               startProgress=0.0,
+                                               endProgress=0.05)
 
-        nsf_f, nsf_1 = FlippingRatioCorrectionMD(
-            InputWorkspace=nsf_mde, FlippingRatio=flipping_ratio, SampleLogs=var_names
-        )
-        progress.report(int(endrange * 0.1), "FlippingRatioCorrectionMD for NSF")
+        nsf_f, nsf_1 = FlippingRatioCorrectionMD(InputWorkspace=nsf_mde,
+                                                 FlippingRatio=flipping_ratio,
+                                                 SampleLogs=var_names,
+                                                 startProgress=0.05,
+                                                 endProgress=0.1)
 
         # make slices for each polarized workspace
         # sf_f
         sf_slice_output_f = sf_slice_name + "_F"
         slice_input = sf_f.name()
-        MakeSlice(InputWorkspace=slice_input, OutputWorkspace=sf_slice_output_f, **makeslice_parameters)
-        progress.report(int(endrange * 0.3), "MakeSlice SF_F")
+        MakeSlice(InputWorkspace=slice_input,
+                  OutputWorkspace=sf_slice_output_f,
+                  **makeslice_parameters,
+                  startProgress=0.1,
+                  endProgress=0.3)
 
         # sf_1
         sf_slice_output_1 = sf_slice_name + "_1"
         slice_input = sf_1.name()
-        MakeSlice(InputWorkspace=slice_input, OutputWorkspace=sf_slice_output_1, **makeslice_parameters)
-        progress.report(int(endrange * 0.5), "MakeSlice SF_1")
+        MakeSlice(InputWorkspace=slice_input,
+                  OutputWorkspace=sf_slice_output_1,
+                  **makeslice_parameters,
+                  startProgress=0.3,
+                  endProgress=0.5)
 
         # nsf_f
         nsf_slice_output_f = nsf_slice_name + "_F"
         slice_input = nsf_f.name()
-        MakeSlice(InputWorkspace=slice_input, OutputWorkspace=nsf_slice_output_f, **makeslice_parameters)
-        progress.report(int(endrange * 0.7), "MakeSlice NSF_F")
+        MakeSlice(InputWorkspace=slice_input,
+                  OutputWorkspace=nsf_slice_output_f,
+                  **makeslice_parameters,
+                  startProgress=0.5,
+                  endProgress=0.7)
+
 
         # nsf_1
         nsf_slice_output_1 = nsf_slice_name + "_1"
         slice_input = nsf_1.name()
-        MakeSlice(InputWorkspace=slice_input, OutputWorkspace=nsf_slice_output_1, **makeslice_parameters)
-        progress.report(int(endrange * 0.9), "MakeSlice NSF_1")
+        MakeSlice(InputWorkspace=slice_input,
+                  OutputWorkspace=nsf_slice_output_1,
+                  **makeslice_parameters,
+                  startProgress=0.7,
+                  endProgress=0.9)
 
         # workspace calculations
         sf_output = sf_slice_name
@@ -215,7 +226,6 @@ class MakeSFCorrectedSlices(DataProcessorAlgorithm):
                 ]
             )
             raise err
-        progress.report(endrange, "Done")
         Comment(sf_output, f"Shiver version {__version__}")
         Comment(nsf_output, f"Shiver version {__version__}")
 

--- a/src/shiver/models/makeslices.py
+++ b/src/shiver/models/makeslices.py
@@ -142,55 +142,66 @@ class MakeSFCorrectedSlices(DataProcessorAlgorithm):
             makeslice_parameters[par_name] = self.getProperty(par_name).value
 
         # corrections
-        sf_f, sf_1 = FlippingRatioCorrectionMD(InputWorkspace=sf_mde,
-                                               FlippingRatio=flipping_ratio,
-                                               SampleLogs=var_names,
-                                               startProgress=0.0,
-                                               endProgress=0.05)
+        sf_f, sf_1 = FlippingRatioCorrectionMD(
+            InputWorkspace=sf_mde,
+            FlippingRatio=flipping_ratio,
+            SampleLogs=var_names,
+            startProgress=0.0,
+            endProgress=0.05,
+        )
 
-        nsf_f, nsf_1 = FlippingRatioCorrectionMD(InputWorkspace=nsf_mde,
-                                                 FlippingRatio=flipping_ratio,
-                                                 SampleLogs=var_names,
-                                                 startProgress=0.05,
-                                                 endProgress=0.1)
+        nsf_f, nsf_1 = FlippingRatioCorrectionMD(
+            InputWorkspace=nsf_mde,
+            FlippingRatio=flipping_ratio,
+            SampleLogs=var_names,
+            startProgress=0.05,
+            endProgress=0.1,
+        )
 
         # make slices for each polarized workspace
         # sf_f
         sf_slice_output_f = sf_slice_name + "_F"
         slice_input = sf_f.name()
-        MakeSlice(InputWorkspace=slice_input,
-                  OutputWorkspace=sf_slice_output_f,
-                  **makeslice_parameters,
-                  startProgress=0.1,
-                  endProgress=0.3)
+        MakeSlice(
+            InputWorkspace=slice_input,
+            OutputWorkspace=sf_slice_output_f,
+            **makeslice_parameters,
+            startProgress=0.1,
+            endProgress=0.3,
+        )
 
         # sf_1
         sf_slice_output_1 = sf_slice_name + "_1"
         slice_input = sf_1.name()
-        MakeSlice(InputWorkspace=slice_input,
-                  OutputWorkspace=sf_slice_output_1,
-                  **makeslice_parameters,
-                  startProgress=0.3,
-                  endProgress=0.5)
+        MakeSlice(
+            InputWorkspace=slice_input,
+            OutputWorkspace=sf_slice_output_1,
+            **makeslice_parameters,
+            startProgress=0.3,
+            endProgress=0.5,
+        )
 
         # nsf_f
         nsf_slice_output_f = nsf_slice_name + "_F"
         slice_input = nsf_f.name()
-        MakeSlice(InputWorkspace=slice_input,
-                  OutputWorkspace=nsf_slice_output_f,
-                  **makeslice_parameters,
-                  startProgress=0.5,
-                  endProgress=0.7)
-
+        MakeSlice(
+            InputWorkspace=slice_input,
+            OutputWorkspace=nsf_slice_output_f,
+            **makeslice_parameters,
+            startProgress=0.5,
+            endProgress=0.7,
+        )
 
         # nsf_1
         nsf_slice_output_1 = nsf_slice_name + "_1"
         slice_input = nsf_1.name()
-        MakeSlice(InputWorkspace=slice_input,
-                  OutputWorkspace=nsf_slice_output_1,
-                  **makeslice_parameters,
-                  startProgress=0.7,
-                  endProgress=0.9)
+        MakeSlice(
+            InputWorkspace=slice_input,
+            OutputWorkspace=nsf_slice_output_1,
+            **makeslice_parameters,
+            startProgress=0.7,
+            endProgress=0.9,
+        )
 
         # workspace calculations
         sf_output = sf_slice_name

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -175,12 +175,8 @@ class HistogramPresenter:  # pylint: disable=too-many-public-methods
     def save_polarization_logs(self, name, sample_logs):
         """Called by the view to retrieve the values for the sample logs"""
 
-        # map the sample logs names requested to the actual sample logs saved in the workspace
-        sample_log_mapping = {"PSDA": "psda"}
         for sample_log, value in sample_logs.items():
-            if sample_log in sample_log_mapping:
-                self.model.save_experiment_sample_log(name, sample_log_mapping[sample_log], value)
-            else:
+            if sample_log != "PSDA":
                 self.model.save_experiment_sample_log(name, sample_log, value)
 
     def create_corrections_tab(self, name):

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -173,7 +173,7 @@ class HistogramPresenter:  # pylint: disable=too-many-public-methods
         return sample_log_data
 
     def save_polarization_logs(self, name, sample_logs):
-        """Called by the view to retrieve the values for the sample logs"""
+        """Called by the view to save the values for the sample logs"""
 
         for sample_log, value in sample_logs.items():
             if sample_log != "PSDA":

--- a/src/shiver/views/histogram_parameters.py
+++ b/src/shiver/views/histogram_parameters.py
@@ -610,11 +610,11 @@ class Dimensions(QWidget):
         self.positive_double_validator = QtGui.QDoubleValidator(self)
         self.positive_double_validator.setBottom(1e-10)
         # standard decimal point-format for example: 1.2
-        self.positive_double_validator.setNotation(QtGui.QDoubleValidator.StandardNotation)
+        self.positive_double_validator.setNotation(QtGui.QDoubleValidator.ScientificNotation)
 
         self.double_validator = QtGui.QDoubleValidator(self)
         # standard decimal point-format for example: 1.2
-        self.double_validator.setNotation(QtGui.QDoubleValidator.StandardNotation)
+        self.double_validator.setNotation(QtGui.QDoubleValidator.ScientificNotation)
 
         self.combo_dimensions = ["[H,0,0]", "[0,K,0]", "[0,0,L]", "DeltaE"]
         self.previous_dimension_value_indexes = [0, 1, 2, 3]

--- a/src/shiver/views/polarized_options.py
+++ b/src/shiver/views/polarized_options.py
@@ -377,7 +377,7 @@ class PolarizedDialog(QDialog):
         else:
             self.state_no_spin.setChecked(True)
 
-        # polarizatio direction is an optional parameter
+        # polarization direction is an optional parameter
         if (
             "PolarizationDirection" not in params
             or params["PolarizationDirection"] == "Pz"

--- a/src/shiver/views/polarized_options.py
+++ b/src/shiver/views/polarized_options.py
@@ -333,7 +333,7 @@ class PolarizedDialog(QDialog):
         state = None
         if self.state_unpolarized.isChecked():
             state = "UNP"
-        if self.state_spin.isChecked():
+        elif self.state_spin.isChecked():
             state = "SF"
         else:
             state = "NSF"
@@ -372,12 +372,17 @@ class PolarizedDialog(QDialog):
         """Set state and direction from polarized state"""
         if params["PolarizationState"] == "UNP" or params["PolarizationState"] is None:
             self.state_unpolarized.setChecked(True)
-            return
-        if params["PolarizationState"] == "SF":
+        elif params["PolarizationState"] == "SF":
             self.state_spin.setChecked(True)
         else:
             self.state_no_spin.setChecked(True)
-        if params["PolarizationDirection"] == "Pz" or params["PolarizationDirection"] is None:
+
+        # polarizatio direction is an optional parameter
+        if (
+            "PolarizationDirection" not in params
+            or params["PolarizationDirection"] == "Pz"
+            or params["PolarizationDirection"] is None
+        ):
             self.dir_pz.setChecked(True)
         elif params["PolarizationDirection"] == "Px":
             self.dir_px.setChecked(True)
@@ -389,7 +394,7 @@ class PolarizedDialog(QDialog):
         # check dictionary format
         expected_keys = [
             "PolarizationState",
-            "PolarizationDirection",
+            # "PolarizationDirection",
             "FlippingRatio",
             "FlippingRatioSampleLog",
             "PSDA",

--- a/src/shiver/views/polarized_options.py
+++ b/src/shiver/views/polarized_options.py
@@ -154,7 +154,7 @@ class PolarizedDialog(QDialog):
         self.ratio_input.setSizePolicy(size_policy)
 
         # log
-        self.log_label = QLabel("Flipping Sample log")
+        self.log_label = QLabel("Flipping Ratio Sample log")
         self.log_label.setToolTip(fr_tooltip)
         layout.addWidget(self.log_label, 2, 2)
         self.log_input = QLineEdit()

--- a/src/shiver/views/reduction_parameters.py
+++ b/src/shiver/views/reduction_parameters.py
@@ -207,10 +207,7 @@ class ReductionParameters(QGroupBox):
         if self.dict_polarized:
             dialog.populate_pol_options_from_dict(self.dict_polarized)
         dialog.exec_()
-        if self.dict_polarized and self.dict_polarized["PolarizationState"] is not None:
-            self.polarization_label.setText(self.dict_polarized["PolarizationState"])
-        else:
-            self.polarization_label.setText("Unpolarized Data")
+        self.update_polarization_label()
         self.active_dialog = None
 
     def get_reduction_params_dict(self):
@@ -264,4 +261,13 @@ class ReductionParameters(QGroupBox):
         self.dict_polarized = params.get("PolarizedOptions", {})
 
         # update polarization label
-        self.polarization_label.setText(self.dict_polarized.get("PolarizationState", "Unpolarized Data"))
+        self.update_polarization_label()
+
+    def update_polarization_label(self):
+        """It updates the label with the plarization state and direction"""
+        display_pol_state = self.dict_polarized.get("PolarizationState")
+        if display_pol_state in ["SF", "NSF"]:
+            display_pol_state += "_" + self.dict_polarized.get("PolarizationDirection")
+        else:
+            display_pol_state = "Unpolarized Data"
+        self.polarization_label.setText(display_pol_state)

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -451,8 +451,8 @@ class MDEList(ADSList):  # pylint: disable=too-many-public-methods
         input_dict_polarized = self.get_polarization_logs_callback(name)
         dialog.populate_pol_options_from_dict(input_dict_polarized)
         dialog.exec_()
-        # if user updated the polarization options
-        if self.dict_polarized != input_dict_polarized:
+        # if user updated the polarization options and hit "Apply"
+        if self.dict_polarized is not None and self.dict_polarized != input_dict_polarized:
             # save them in the workspace
             self.save_polarization_logs_callback(name, self.dict_polarized)
 

--- a/tests/models/test_histogram_saving.py
+++ b/tests/models/test_histogram_saving.py
@@ -222,7 +222,7 @@ def test_polarization_state_sf(tmp_path):
 
 
 def test_polarization_parameters(tmp_path, shiver_app, qtbot):
-    """Test the polarization parameters are saved as a sample logs in the workspace: NSF state"""
+    """Test the polarization parameters are saved as sample logs in the workspace: NSF state"""
 
     name = "test_workspace"
 
@@ -275,7 +275,7 @@ def test_polarization_parameters(tmp_path, shiver_app, qtbot):
 
 
 def test_polarization_state_invalid(tmp_path):
-    """Test the polarization state is saved as a sample log in the workspace: SF state"""
+    """Test the polarization state for invalid state"""
 
     name = "test_workspace"
     pol_state = "unpol"
@@ -311,7 +311,7 @@ def test_polarization_state_invalid(tmp_path):
 
 
 def test_polarization_state_no_saved_state(tmp_path):
-    """Test the polarization state is saved as a sample log in the workspace: SF state"""
+    """Test default state"""
 
     name = "test_workspace"
 

--- a/tests/models/test_histogram_saving.py
+++ b/tests/models/test_histogram_saving.py
@@ -76,11 +76,11 @@ def test_experiment_sample_log_valid(tmp_path):
     # check polarization state in sample logs
     workspace = mtd[name]
     run = workspace.getExperimentInfo(0).run()
-    saved_pol_state = run.getLogData("polarization_state").value
+    saved_pol_state = run.getLogData("PolarizationState").value
     assert saved_pol_state == pol_state
 
     # retrieve the state
-    experiment_state = model.get_experiment_sample_log(workspace, "polarization_state")
+    experiment_state = model.get_experiment_sample_log(name, "PolarizationState")
     assert experiment_state is not None
     assert experiment_state == pol_state
 
@@ -107,9 +107,8 @@ def test_experiment_sample_log_invalid(tmp_path):
     model.save_history(name, str(tmp_path / "test_workspace.py"))
 
     # check polarization state is not in sample logs
-    workspace = mtd[name]
     # retrieve the state
-    experiment_state = model.get_experiment_sample_log(workspace, "po")
+    experiment_state = model.get_experiment_sample_log(name, "po")
     assert experiment_state is None
 
 
@@ -140,7 +139,7 @@ def test_polarization_state_unpol(tmp_path):
     # check polarization state in sample logs
     workspace = mtd[name]
     run = workspace.getExperimentInfo(0).run()
-    saved_pol_state = run.getLogData("polarization_state").value
+    saved_pol_state = run.getLogData("PolarizationState").value
     assert saved_pol_state == pol_state
 
     # retrieve the state after
@@ -175,7 +174,7 @@ def test_polarization_state_nsf(tmp_path):
     # check polarization state in sample logs
     workspace = mtd[name]
     run = workspace.getExperimentInfo(0).run()
-    saved_pol_state = run.getLogData("polarization_state").value
+    saved_pol_state = run.getLogData("PolarizationState").value
     assert saved_pol_state == pol_state
 
     # retrieve the state after
@@ -210,7 +209,7 @@ def test_polarization_state_sf(tmp_path):
     # check polarization state in sample logs
     workspace = mtd[name]
     run = workspace.getExperimentInfo(0).run()
-    saved_pol_state = run.getLogData("polarization_state").value
+    saved_pol_state = run.getLogData("PolarizationState").value
     assert saved_pol_state == pol_state
 
     # retrieve the state after
@@ -247,7 +246,7 @@ def test_polarization_state_invalid(tmp_path):
 
     # check polarization state is not in sample logs
     run = workspace.getExperimentInfo(0).run()
-    assert "polarization_state" not in run.keys()
+    assert "PolarizationState" not in run.keys()
 
     # retrieve the state after, UNP is default
     after_pol_state = model.get_polarization_state(name)
@@ -307,7 +306,7 @@ def test_get_flipping_ratio_number(tmp_path):
     AddSampleLog(workspace, LogName="FlippingRatio", LogText="9", LogType="String")
 
     # retrieve the flipping ratio
-    flipping_ratio = model.get_flipping_ratio(workspace)
+    flipping_ratio = model.get_flipping_ratio(name)
     assert flipping_ratio == 9
 
 
@@ -339,7 +338,7 @@ def test_get_flipping_ratio_formula(tmp_path):
     AddSampleLog(workspace, LogName="FlippingRatioSampleLog", LogText="omega", LogType="String")
 
     # retrieve the flipping ratio
-    flipping_ratio = model.get_flipping_ratio(workspace)
+    flipping_ratio = model.get_flipping_ratio(name)
     assert flipping_ratio == "2*omega+9,omega"
 
 
@@ -370,7 +369,7 @@ def test_get_flipping_ratio_formula_invalid(tmp_path):
     AddSampleLog(workspace, LogName="FlippingRatio", LogText="2*omega+9", LogType="String")
 
     # retrieve the flipping ratio
-    flipping_ratio = model.get_flipping_ratio(workspace)
+    flipping_ratio = model.get_flipping_ratio(name)
     assert flipping_ratio is None
 
 

--- a/tests/views/test_mde_workspaces.py
+++ b/tests/views/test_mde_workspaces.py
@@ -161,7 +161,7 @@ def test_mde_workspaces_menu(qtbot):
     item = mde_table.item(0)
     assert item.text() == "mde1"
 
-    QTimer.singleShot(100, partial(handle_menu, 7))
+    QTimer.singleShot(100, partial(handle_menu, 8))
     qtbot.mouseClick(mde_table.viewport(), Qt.MouseButton.LeftButton, pos=mde_table.visualItemRect(item).center())
 
     qtbot.wait(100)
@@ -186,7 +186,7 @@ def test_mde_workspaces_menu(qtbot):
     item = mde_table.item(0)
     assert item.text() == "mde1"
 
-    QTimer.singleShot(100, partial(handle_menu, 6))
+    QTimer.singleShot(100, partial(handle_menu, 7))
     QTimer.singleShot(200, handle_dialog)
     qtbot.mouseClick(mde_table.viewport(), Qt.MouseButton.LeftButton, pos=mde_table.visualItemRect(item).center())
 
@@ -231,7 +231,6 @@ def test_mde_workspaces_menu_nsf(qtbot):
     QTimer.singleShot(100, partial(handle_menu, 1))
     qtbot.mouseClick(mde_table.viewport(), Qt.MouseButton.LeftButton, pos=mde_table.visualItemRect(item).center())
 
-    qtbot.wait(7000)
     assert mde_table.count() == 3
     assert mde_table.data_nsf == "mde1"
     assert mde_table.data_u is None

--- a/tests/views/test_mde_workspaces.py
+++ b/tests/views/test_mde_workspaces.py
@@ -433,7 +433,7 @@ def test_mde_workspaces_all_data():
 
 
 def test_mde_workspaces_menu_polarization_dialog(qtbot):
-    """Test the mde and norm lists"""
+    """Test the polarization dialog workflow from mde list"""
     mdelist = MDEList()
     qtbot.addWidget(mdelist)
     mdelist.show()
@@ -464,14 +464,14 @@ def test_mde_workspaces_menu_polarization_dialog(qtbot):
 
     item = mdelist.item(0)
 
-    # mde_table.dialog = MockDialog()
-    # This is to handle the menu
+    # This is to handle the mdelist menu
     def handle_menu(action_number):
         menu = mdelist.findChild(QMenu)
         for _ in range(action_number):
             qtbot.keyClick(menu, Qt.Key_Down)
         qtbot.keyClick(menu, Qt.Key_Enter)
 
+    # This is to handle the polarization dialog
     def handle_polarization_dialog(mdelist):
         dialog = mdelist.findChild(QDialog)
         apply_btn = dialog.findChild(QPushButton)
@@ -479,9 +479,11 @@ def test_mde_workspaces_menu_polarization_dialog(qtbot):
         qtbot.keyClicks(flipping_ratio, "20")
         qtbot.keyClick(apply_btn, Qt.Key_Enter)
 
+    # select the item
     item = mdelist.item(0)
     assert item.text() == "mde1"
 
+    # click on the menu and polarization dialog
     QTimer.singleShot(100, partial(handle_menu, 5))
     QTimer.singleShot(400, partial(handle_polarization_dialog, mdelist))
     qtbot.mouseClick(mdelist.viewport(), Qt.MouseButton.LeftButton, pos=mdelist.visualItemRect(item).center())

--- a/tests/views/test_polarized_options.py
+++ b/tests/views/test_polarized_options.py
@@ -338,7 +338,7 @@ def test_polarized_options_initialization_from_dict_invalid():
 
 
 def test_polarized_options_invalid_max_psda(qtbot):
-    """Test for making psda as a invalid field"""
+    """Test for adding an invalida maximum value in psda"""
     red_parameters = ReductionParameters()
     dialog = PolarizedDialog(red_parameters)
     dialog.show()
@@ -362,7 +362,7 @@ def test_polarized_options_readonly_psda(qtbot):
 
 
 def test_set_polarized_state_dir_sf_px():
-    """Test set_polarized_state_dir for state and direction fields"""
+    """Test set_polarized_state_dir for state and direction fields: SF-Px"""
     dialog = PolarizedDialog()
     params = {"PolarizationState": "SF", "PolarizationDirection": "Px"}
     dialog.set_polarized_state_dir(params)
@@ -374,7 +374,7 @@ def test_set_polarized_state_dir_sf_px():
 
 
 def test_set_polarized_state_dir_sf_py():
-    """Test set_polarized_state_dir for state and direction fields"""
+    """Test set_polarized_state_dir for state and direction fields: SF-Py"""
     dialog = PolarizedDialog()
     params = {"PolarizationState": "SF", "PolarizationDirection": "Py"}
     dialog.set_polarized_state_dir(params)

--- a/tests/views/test_polarized_options.py
+++ b/tests/views/test_polarized_options.py
@@ -21,9 +21,9 @@ def test_polarized_options_unpolarized(qtbot):
     dict_data = dialog.get_polarized_options_dict()
     # assert values are added in the dictionary
 
-    assert dict_data["PolarizationState"] is None
+    assert dict_data["PolarizationState"] == "UNP"
     assert dict_data["FlippingRatio"] is None
-    assert dict_data["SampleLog"] == ""
+    assert dict_data["FlippingRatioSampleLog"] == ""
     assert dict_data["PSDA"] is None
     qtbot.wait(500)
     dialog.close()
@@ -55,9 +55,10 @@ def test_polarized_options_spin(qtbot):
     dict_data = dialog.get_polarized_options_dict()
     # assert values are added in the dictionary
 
-    assert dict_data["PolarizationState"] == "SF_Px"
+    assert dict_data["PolarizationState"] == "SF"
+    assert dict_data["PolarizationDirection"] == "Px"
     assert dict_data["FlippingRatio"] == "omega+8"
-    assert dict_data["SampleLog"] == "omega"
+    assert dict_data["FlippingRatioSampleLog"] == "omega"
     assert dict_data["PSDA"] == "2"
     dialog.close()
 
@@ -86,9 +87,10 @@ def test_polarized_options_no_spin(qtbot):
     dict_data = dialog.get_polarized_options_dict()
     # assert values are added in the dictionary
 
-    assert dict_data["PolarizationState"] == "NSF_Py"
+    assert dict_data["PolarizationState"] == "NSF"
+    assert dict_data["PolarizationDirection"] == "Py"
     assert dict_data["FlippingRatio"] == "sin(kapa)*1.2+4.54"
-    assert dict_data["SampleLog"] == "kapa"
+    assert dict_data["FlippingRatioSampleLog"] == "kapa"
     assert dict_data["PSDA"] == "5"
 
     dialog.close()
@@ -116,9 +118,10 @@ def test_polarized_options_ratio_num(qtbot):
     dict_data = dialog.get_polarized_options_dict()
     # assert values are added in the dictionary
 
-    assert dict_data["PolarizationState"] == "SF_Pz"
+    assert dict_data["PolarizationState"] == "SF"
+    assert dict_data["PolarizationDirection"] == "Pz"
     assert dict_data["FlippingRatio"] == "8"
-    assert dict_data["SampleLog"] == ""
+    assert dict_data["FlippingRatioSampleLog"] == ""
     assert dict_data["PSDA"] == "2"
     dialog.close()
 
@@ -193,9 +196,10 @@ def test_apply_btn_valid_all(qtbot):
     dict_data = dialog.parent.dict_polarized
 
     # assert values are added in parent dictionary
-    assert dict_data["PolarizationState"] == "NSF_Pz"
+    assert dict_data["PolarizationState"] == "NSF"
+    assert dict_data["PolarizationDirection"] == "Pz"
     assert dict_data["FlippingRatio"] == "6.78+3.9*pi"
-    assert dict_data["SampleLog"] == "pi"
+    assert dict_data["FlippingRatioSampleLog"] == "pi"
     assert dict_data["PSDA"] is None
     dialog.close()
 
@@ -225,9 +229,10 @@ def test_apply_btn_valid(qtbot):
     dict_data = dialog.parent.dict_polarized
 
     # assert values are added in parent dictionary
-    assert dict_data["PolarizationState"] == "NSF_Pz"
+    assert dict_data["PolarizationState"] == "NSF"
+    assert dict_data["PolarizationDirection"] == "Pz"
     assert dict_data["FlippingRatio"] == "6.78"
-    assert dict_data["SampleLog"] == ""
+    assert dict_data["FlippingRatioSampleLog"] == ""
     assert dict_data["PSDA"] == "3.45"
     dialog.close()
 
@@ -255,7 +260,13 @@ def test_polarized_options_initialization_from_dict_nsf():
     dialog = PolarizedDialog(red_parameters)
     dialog.show()
 
-    params = {"PolarizationState": "NSF_Pz", "FlippingRatio": "6.78+3.9*pi", "SampleLog": "pi", "PSDA": None}
+    params = {
+        "PolarizationState": "NSF",
+        "PolarizationDirection": "Pz",
+        "FlippingRatio": "6.78+3.9*pi",
+        "FlippingRatioSampleLog": "pi",
+        "PSDA": None,
+    }
     dialog.populate_pol_options_from_dict(params)
 
     # assert fields are populated properly
@@ -271,7 +282,7 @@ def test_polarized_options_initialization_from_dict_nsf():
 
     assert dialog.ratio_input.text() == params["FlippingRatio"]
     assert dialog.ratio_input.isVisible() is True
-    assert dialog.log_input.text() == params["SampleLog"]
+    assert dialog.log_input.text() == params["FlippingRatioSampleLog"]
     assert dialog.ratio_input.isVisible() is True
     assert dialog.psda_input.text() == ""
     assert len(dialog.invalid_fields) == 0
@@ -285,7 +296,7 @@ def test_polarized_options_initialization_from_dict_unpolarized():
     dialog = PolarizedDialog(red_parameters)
     dialog.show()
 
-    params = {"PolarizationState": "Unpolarized Data", "FlippingRatio": None, "SampleLog": "", "PSDA": 2.2}
+    params = {"PolarizationState": "UNP", "FlippingRatio": None, "FlippingRatioSampleLog": "", "PSDA": 2.2}
     dialog.populate_pol_options_from_dict(params)
 
     # assert fields are populated properly
@@ -316,7 +327,7 @@ def test_polarized_options_initialization_from_dict_invalid():
     dialog = PolarizedDialog(red_parameters)
     dialog.show()
 
-    params = {"p": "Unpolarized Data", "FlippingRatio": None, "SampleLog": "", "PSDA": 9.4}
+    params = {"p": "UNP", "FlippingRatio": None, "FlippingRatioSampleLog": "", "PSDA": 9.4}
 
     # This is to handle modal dialog expected error
     def handle_dialog():

--- a/tests/views/test_polarized_options.py
+++ b/tests/views/test_polarized_options.py
@@ -335,3 +335,51 @@ def test_polarized_options_initialization_from_dict_invalid():
 
     QtCore.QTimer.singleShot(500, partial(handle_dialog))
     dialog.populate_pol_options_from_dict(params)
+
+
+def test_polarized_options_invalid_max_psda(qtbot):
+    """Test for making psda as a invalid field"""
+    red_parameters = ReductionParameters()
+    dialog = PolarizedDialog(red_parameters)
+    dialog.show()
+
+    qtbot.keyClicks(dialog.psda_input, "20")
+    assert dialog.psda_input.text() == "20"
+    assert len(dialog.invalid_fields) == 1
+
+    dialog.close()
+
+
+def test_polarized_options_readonly_psda(qtbot):
+    """Test for making psda as a readonly field"""
+    red_parameters = ReductionParameters()
+    dialog = PolarizedDialog(red_parameters, disable_psda=True)
+    dialog.show()
+
+    qtbot.keyClicks(dialog.psda_input, "3.8")
+    assert dialog.psda_input.text() == ""
+    dialog.close()
+
+
+def test_set_polarized_state_dir_sf_px():
+    """Test set_polarized_state_dir for state and direction fields"""
+    dialog = PolarizedDialog()
+    params = {"PolarizationState": "SF", "PolarizationDirection": "Px"}
+    dialog.set_polarized_state_dir(params)
+    dialog.show()
+
+    assert dialog.dir_px.isChecked()
+    assert dialog.state_spin.isChecked()
+    dialog.close()
+
+
+def test_set_polarized_state_dir_sf_py():
+    """Test set_polarized_state_dir for state and direction fields"""
+    dialog = PolarizedDialog()
+    params = {"PolarizationState": "SF", "PolarizationDirection": "Py"}
+    dialog.set_polarized_state_dir(params)
+    dialog.show()
+
+    assert dialog.dir_py.isChecked()
+    assert dialog.state_spin.isChecked()
+    dialog.close()

--- a/tests/views/test_reduction_parameters_inputs.py
+++ b/tests/views/test_reduction_parameters_inputs.py
@@ -260,9 +260,9 @@ def test_reduction_parameters_initialization_from_dict_to_dict(qtbot):
             "v": "-0.07069,-3.18894,-5.85775",
         },
         "PolarizedOptions": {
-            "PolarizationState": "Unpolarized Data",
+            "PolarizationState": "UNP",
             "FlippingRatio": None,
-            "SampleLog": "",
+            "FlippingRatioSampleLog": "",
             "PSDA": 2.2,
         },
     }

--- a/tests/views/test_reduction_parameters_inputs.py
+++ b/tests/views/test_reduction_parameters_inputs.py
@@ -386,3 +386,15 @@ def test_reduction_parameters_initialization_from_dict_to_dict(qtbot):
     QtCore.QTimer.singleShot(500, partial(handle_pol_dialog))
     qtbot.mouseClick(red_params.pol_btn, QtCore.Qt.LeftButton)
     qtbot.waitUntil(dialog_completed, timeout=5000)
+
+
+def test_update_polarization_label(qtbot):
+    """Test for the polarization label"""
+
+    generate = Generate()
+    generate.show()
+    qtbot.addWidget(generate)
+    red_params = generate.reduction_parameters
+    red_params.dict_polarized = {"PolarizationState": "SF", "PolarizationDirection": "Px"}
+    red_params.update_polarization_label()
+    assert red_params.polarization_label.text() == "SF_Px"


### PR DESCRIPTION
The code has the following:
1. The polarization dialog appears in the mde workslace list in the main tab. In this case the parameters:             
  "PolarizationState",
  "PolarizationDirection",
  "FlippingRatio",
  "FlippingRatioSampleLog",
  "PSDA",  are saved as sample logs in the workspace. PSDA appears as a readonly field.
3. In the Generate tab for a specific mde workspace, the polarization parameters are retrieved from the corresponding sample logs. They are saved as separate sample logs on "Generate" button click.
4. Code restructure. Internal functions in histogram model, pass around workspace name over the actual workspace.
5. Sample log PolarizationDirection = "Pz", set as default for NSF and SF polarized workspaces. The sample log is saved, when the polarization state is only saved from mde workspace list , to avoid inconsistencies/bugs.
6. Tests are updated and added regarding the above changes