### PR TITLE
Workspace Data Consistency between Main and Generate/Provenance Tabs

### DIFF
--- a/src/shiver/models/generate.py
+++ b/src/shiver/models/generate.py
@@ -46,7 +46,7 @@ class GenerateModel:
 
         # disable the Generate button to prevent multiple clicks
         if self.generate_mde_finish_callback:
-            self.generate_mde_finish_callback(False)
+            self.generate_mde_finish_callback(False, False)
 
         # remove output workspace if it exists in memory
         output_workspace = config_dict.get("mde_name", "")
@@ -198,7 +198,7 @@ class GenerateModel:
             self.config_dict = None
             # enable button
             if self.generate_mde_finish_callback:
-                self.generate_mde_finish_callback(True)
+                self.generate_mde_finish_callback(True, False)
             if self.error_callback:
                 self.error_callback(msg=err_msg)
         else:
@@ -279,8 +279,8 @@ class GenerateModel:
         self.output_dir = None
 
         self.algorithm_observer.remove(obs)
-        # enable button
-        self.generate_mde_finish_callback(True)
+        # enable button and update the newly-save workspace name
+        self.generate_mde_finish_callback(True, True)
 
 
 class GenerateMDEObserver(AlgorithmObserver):

--- a/src/shiver/models/generate.py
+++ b/src/shiver/models/generate.py
@@ -203,11 +203,12 @@ class GenerateModel:
                 self.error_callback(msg=err_msg)
         else:
             logger.information("GenerateDGSMDE finished")
+
             # attach config_dict to the workspace
-            workspace = mtd[self.workspace_name]
-            workspace.getExperimentInfo(0).mutableRun().addProperty("MDEConfig", str(self.config_dict), True)
+            save_mde_config_dict(self.workspace_name, self.config_dict)
 
             # save polarization sample logs separately
+            workspace = mtd[self.workspace_name]
             if self.config_dict["PolarizedOptions"]:
                 for field, value in self.config_dict["PolarizedOptions"].items():
                     if field != "PSDA":
@@ -349,3 +350,9 @@ def gather_mde_config_dict(workspace_name: str) -> dict:
     config.update(ast.literal_eval(config_str))
 
     return config
+
+
+def save_mde_config_dict(workspace_name, config_dict):
+    """Save the config dictionary in the given MDE workspace."""
+    workspace = mtd[workspace_name]
+    workspace.getExperimentInfo(0).mutableRun().addProperty("MDEConfig", str(config_dict), True)

--- a/src/shiver/models/generate.py
+++ b/src/shiver/models/generate.py
@@ -46,7 +46,7 @@ class GenerateModel:
 
         # disable the Generate button to prevent multiple clicks
         if self.generate_mde_finish_callback:
-            self.generate_mde_finish_callback(False, False)
+            self.generate_mde_finish_callback(False)
 
         # remove output workspace if it exists in memory
         output_workspace = config_dict.get("mde_name", "")
@@ -198,7 +198,7 @@ class GenerateModel:
             self.config_dict = None
             # enable button
             if self.generate_mde_finish_callback:
-                self.generate_mde_finish_callback(True, False)
+                self.generate_mde_finish_callback(True)
             if self.error_callback:
                 self.error_callback(msg=err_msg)
         else:
@@ -213,6 +213,9 @@ class GenerateModel:
                 for field, value in self.config_dict["PolarizedOptions"].items():
                     if field != "PSDA":
                         AddSampleLog(workspace, LogName=field, LogText=value, LogType="String")
+                    else:
+                        # psda is saved as a small character name
+                        AddSampleLog(workspace, LogName="psda", LogText=value, LogType="String")
 
             # kick off the saving of the output to disk
             self.save_mde_to_disk()
@@ -279,8 +282,8 @@ class GenerateModel:
         self.output_dir = None
 
         self.algorithm_observer.remove(obs)
-        # enable button and update the newly-save workspace name
-        self.generate_mde_finish_callback(True, True)
+        # enable button
+        self.generate_mde_finish_callback(True)
 
 
 class GenerateMDEObserver(AlgorithmObserver):

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -374,15 +374,11 @@ class HistogramModel:  # pylint: disable=too-many-public-methods
         # SpinFlip workspace
         # init PolarizedModel
         polarized_model = PolarizedModel(config.get("SFInputWorkspace"))
-        # connect error message
-        # polarized_model.connect_error_message(self.error_message)
         sf_flipping_ratio = polarized_model.get_flipping_ratio()
 
         # NonSpinflip workspace
         # init PolarizedModel
         polarized_model = PolarizedModel(config.get("NSFInputWorkspace"))
-        # connect error message
-        # polarized_model.connect_error_message(self.error_message)
         nsf_flipping_ratio = polarized_model.get_flipping_ratio()
 
         # compare the flipping ratios of the two workspaces gathered from sample logs

--- a/src/shiver/models/polarized.py
+++ b/src/shiver/models/polarized.py
@@ -32,60 +32,82 @@ class PolarizedModel:
 
     def get_polarization_logs(self):
         """Get polarization logs from workspace"""
-        return get_polarization_logs_for_workspace(self.workspace_name)
+        return self.get_polarization_logs_for_workspace()
 
+    def get_experiment_sample_log(self, log_name):
+        """Get the sample log with name"""
+        log_value = None
+        if self.workspace_name and mtd.doesExist(self.workspace_name):
+            workspace = mtd[self.workspace_name]
+            if hasattr(workspace, "getExperimentInfo"):
+                try:
+                    run = workspace.getExperimentInfo(0).run()
+                    if log_name in run.keys():
+                        if run.getLogData(log_name).type == "string":
+                            log_value = run.getLogData(log_name).value
+                        else:
+                            log_value = run.getPropertyAsSingleValueWithTimeAveragedMean(log_name)
+                except ValueError as err:
+                    err_msg = f"Experiment info error {err}."
+                    logger.error(err_msg)
+        return log_value
 
-def get_polarization_logs_for_workspace(workspace):
-    """Get polarization logs from workspace"""
-    pol_sample_logs = [
-        "PolarizationState",
-        "PolarizationDirection",
-        "FlippingRatio",
-        "FlippingRatioSampleLog",
-        "psda",
-    ]
-    sample_log_data = {}
-    for sample_log in pol_sample_logs:
-        sample_log_data[sample_log] = get_experiment_sample_log(workspace, sample_log)
-    return sample_log_data
+    def save_polarization_state(self, pol_state):
+        """Save the polarization state as Sample Log in workspace"""
+        # valid pol_states should be: UNP, SF or NSF
+        if pol_state in ["UNP", "SF", "NSF"]:
+            self.save_experiment_sample_log("PolarizationState", pol_state)
+            if pol_state in ["SF", "NSF"]:
+                polarization_direction_log = self.get_experiment_sample_log("PolarizationDirection")
+                if polarization_direction_log is None:
+                    # add default polarization direction if it does not exist
+                    self.save_experiment_sample_log("PolarizationDirection", "Pz")
+        else:
+            err_msg = "Invalid polarization state"
+            logger.error(err_msg)
+            if self.error_callback:
+                self.error_callback(err_msg)
 
+    def get_polarization_state(self):
+        """Get the polarization state from Sample Log in workspace"""
+        pol_state = self.get_experiment_sample_log("PolarizationState")
+        if pol_state is None:
+            # revert to default unpolarized state
+            pol_state = "UNP"
+        return pol_state
 
-def get_flipping_ratio(workspace):
-    """Method to return the flipping ratio for a workspace"""
+    def get_polarization_logs_for_workspace(self):
+        """Get polarization logs from workspace"""
+        pol_sample_logs = [
+            "PolarizationState",
+            "PolarizationDirection",
+            "FlippingRatio",
+            "FlippingRatioSampleLog",
+            "psda",
+        ]
+        sample_log_data = {}
+        for sample_log in pol_sample_logs:
+            sample_log_data[sample_log] = self.get_experiment_sample_log(sample_log)
+        return sample_log_data
 
-    # get flipping ratio and flippingsamplelog values
-    flipping_formula = get_experiment_sample_log(workspace, "FlippingRatio")
-    sample_log = get_experiment_sample_log(workspace, "FlippingRatioSampleLog")
+    def get_flipping_ratio(self):
+        """Method to return the flipping ratio for a workspace"""
 
-    # calculate the flipping ratio
-    flipping_ratio = None
-    if flipping_formula is not None:
-        try:
-            # case 1 flipping formula is a number
-            flipping_ratio = float(flipping_formula)
-        except ValueError:
-            # case 2 flipping formula is an expression
-            if sample_log is not None:
-                flipping_ratio = f"{flipping_formula},{sample_log}"
-            else:
-                err = f"{flipping_formula} is invalid!"
-                logger.error(err)
-    return flipping_ratio
+        # get flipping ratio and flippingsamplelog values
+        flipping_formula = self.get_experiment_sample_log("FlippingRatio")
+        sample_log = self.get_experiment_sample_log("FlippingRatioSampleLog")
 
-
-def get_experiment_sample_log(name, log_name):
-    """Get the sample log with name"""
-    log_value = None
-    if name and mtd.doesExist(name):
-        workspace = mtd[name]
-        if hasattr(workspace, "getExperimentInfo"):
+        # calculate the flipping ratio
+        flipping_ratio = None
+        if flipping_formula is not None:
             try:
-                run = workspace.getExperimentInfo(0).run()
-                if log_name in run.keys():
-                    if run.getLogData(log_name).type == "string":
-                        log_value = run.getLogData(log_name).value
-                    else:
-                        log_value = run.getPropertyAsSingleValueWithTimeAveragedMean(log_name)
-            except ValueError as err:
-                logger.error(f"Experiment info error {err}.")
-    return log_value
+                # case 1 flipping formula is a number
+                flipping_ratio = float(flipping_formula)
+            except ValueError:
+                # case 2 flipping formula is an expression
+                if sample_log is not None:
+                    flipping_ratio = f"{flipping_formula},{sample_log}"
+                else:
+                    err = f"{flipping_formula} is invalid!"
+                    logger.error(err)
+        return flipping_ratio

--- a/src/shiver/models/polarized.py
+++ b/src/shiver/models/polarized.py
@@ -1,0 +1,91 @@
+"""Model for the Sample Parameters dialog"""
+# pylint: disable=no-name-in-module
+from mantid.simpleapi import mtd, AddSampleLog
+from mantid.kernel import Logger
+
+
+logger = Logger("SHIVER")
+
+
+class PolarizedModel:
+    """Polarized model"""
+
+    def __init__(self, workspace_name=None):
+        self.error_callback = None
+        self.workspace_name = workspace_name
+
+    def connect_error_message(self, callback):
+        """Set the callback function for error messages"""
+        self.error_callback = callback
+
+    def save_experiment_sample_log(self, log_name, log_value):
+        """Add the sample log with log_name and log_value in the workspace with name"""
+        if self.workspace_name and mtd.doesExist(self.workspace_name):
+            workspace = mtd[self.workspace_name]
+            AddSampleLog(workspace, LogName=log_name, LogText=log_value, LogType="String")
+
+    def save_polarization_logs(self, polarization_logs):
+        """Save polarization logs in workspace"""
+        if self.workspace_name and mtd.doesExist(self.workspace_name):
+            for pol_log, value in polarization_logs.items():
+                self.save_experiment_sample_log(pol_log, value)
+
+    def get_polarization_logs(self):
+        """Get polarization logs from workspace"""
+        return get_polarization_logs_for_workspace(self.workspace_name)
+
+
+def get_polarization_logs_for_workspace(workspace):
+    """Get polarization logs from workspace"""
+    pol_sample_logs = [
+        "PolarizationState",
+        "PolarizationDirection",
+        "FlippingRatio",
+        "FlippingRatioSampleLog",
+        "psda",
+    ]
+    sample_log_data = {}
+    for sample_log in pol_sample_logs:
+        sample_log_data[sample_log] = get_experiment_sample_log(workspace, sample_log)
+    return sample_log_data
+
+
+def get_flipping_ratio(workspace):
+    """Method to return the flipping ratio for a workspace"""
+
+    # get flipping ratio and flippingsamplelog values
+    flipping_formula = get_experiment_sample_log(workspace, "FlippingRatio")
+    sample_log = get_experiment_sample_log(workspace, "FlippingRatioSampleLog")
+
+    # calculate the flipping ratio
+    flipping_ratio = None
+    if flipping_formula is not None:
+        try:
+            # case 1 flipping formula is a number
+            flipping_ratio = float(flipping_formula)
+        except ValueError:
+            # case 2 flipping formula is an expression
+            if sample_log is not None:
+                flipping_ratio = f"{flipping_formula},{sample_log}"
+            else:
+                err = f"{flipping_formula} is invalid!"
+                logger.error(err)
+    return flipping_ratio
+
+
+def get_experiment_sample_log(name, log_name):
+    """Get the sample log with name"""
+    log_value = None
+    if name and mtd.doesExist(name):
+        workspace = mtd[name]
+        if hasattr(workspace, "getExperimentInfo"):
+            try:
+                run = workspace.getExperimentInfo(0).run()
+                if log_name in run.keys():
+                    if run.getLogData(log_name).type == "string":
+                        log_value = run.getLogData(log_name).value
+                    else:
+                        log_value = run.getPropertyAsSingleValueWithTimeAveragedMean(log_name)
+            except ValueError as err:
+                logger.error(f"Experiment info error {err}.")
+    return log_value

--- a/src/shiver/models/sample.py
+++ b/src/shiver/models/sample.py
@@ -27,7 +27,7 @@ class SampleModel:
         """return oriented lattice object from mtd - if no name provided initialize lattice"""
         if self.name:
             if mtd.doesExist(self.name):
-                self.oriented_lattice = mtd[self.name].getExperimentInfo(0).sample().getOrientedLattice()
+                self.oriented_lattice = get_lattice_for_workspace(self.name)
                 return self.oriented_lattice
             err_msg = f"Workspace {self.name} does not exist\n"
             logger.error(err_msg)
@@ -181,3 +181,11 @@ class SampleModel:
             if self.error_callback:
                 self.error_callback(err_msg)
             return None
+
+
+def get_lattice_for_workspace(workspace):
+    """Get lattice from workspace"""
+    oriented_lattice = None
+    if workspace and mtd.doesExist(workspace):
+        oriented_lattice = mtd[workspace].getExperimentInfo(0).sample().getOrientedLattice()
+    return oriented_lattice

--- a/src/shiver/models/sample.py
+++ b/src/shiver/models/sample.py
@@ -27,7 +27,7 @@ class SampleModel:
         """return oriented lattice object from mtd - if no name provided initialize lattice"""
         if self.name:
             if mtd.doesExist(self.name):
-                self.oriented_lattice = get_lattice_for_workspace(self.name)
+                self.oriented_lattice = mtd[self.name].getExperimentInfo(0).sample().getOrientedLattice()
                 return self.oriented_lattice
             err_msg = f"Workspace {self.name} does not exist\n"
             logger.error(err_msg)
@@ -181,11 +181,3 @@ class SampleModel:
             if self.error_callback:
                 self.error_callback(err_msg)
             return None
-
-
-def get_lattice_for_workspace(workspace):
-    """Get lattice from workspace"""
-    oriented_lattice = None
-    if workspace and mtd.doesExist(workspace):
-        oriented_lattice = mtd[workspace].getExperimentInfo(0).sample().getOrientedLattice()
-    return oriented_lattice

--- a/src/shiver/models/sample.py
+++ b/src/shiver/models/sample.py
@@ -29,12 +29,11 @@ class SampleModel:
             if mtd.doesExist(self.name):
                 self.oriented_lattice = mtd[self.name].getExperimentInfo(0).sample().getOrientedLattice()
                 return self.oriented_lattice
-            err_msg = f"Workspace {self.name} does not exist\n"
+            err_msg = f"Workspace {self.name} does not exist. Lattice from default parameters\n"
             logger.error(err_msg)
             if self.error_callback:
                 self.error_callback(err_msg)
-            return False
-        # no name-workspace provided, create lattice with initial params
+        # no valid name-workspace provided, create lattice with initial params
         params = {
             "a": 1.00000,
             "b": 1.00000,
@@ -101,7 +100,7 @@ class SampleModel:
 
     def set_ub(self, params):
         """Mantid SetUB with current workspace"""
-        if self.name:
+        if self.name and mtd.doesExist(self.name):
             workspace = mtd[self.name]
             # some check
             uvec_cord = params["u"].split(",")

--- a/src/shiver/models/sample.py
+++ b/src/shiver/models/sample.py
@@ -31,8 +31,6 @@ class SampleModel:
                 return self.oriented_lattice
             err_msg = f"Workspace {self.name} does not exist. Lattice from default parameters\n"
             logger.error(err_msg)
-            if self.error_callback:
-                self.error_callback(err_msg)
         # no valid name-workspace provided, create lattice with initial params
         params = {
             "a": 1.00000,

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -9,6 +9,10 @@ from shiver.models.sample import SampleModel
 from shiver.presenters.sample import SamplePresenter
 from shiver.views.sample import SampleView
 
+from shiver.models.generate import GenerateModel
+from shiver.presenters.generate import GeneratePresenter
+from shiver.views.generate import Generate
+
 
 class HistogramPresenter:  # pylint: disable=too-many-public-methods
     """Histogram presenter"""
@@ -135,6 +139,7 @@ class HistogramPresenter:  # pylint: disable=too-many-public-methods
             self.view.add_ws(name, ws_type, frame, ndims)
         elif action == "del":
             self.view.del_ws(name)
+            self.remove_provenance_tab(name)
         elif action == "clear":
             self.view.clear_ws()
 
@@ -301,6 +306,26 @@ class HistogramPresenter:  # pylint: disable=too-many-public-methods
 
         # populate the Generate tab with the MDE config dict
         generate_tab.populate_from_dict(config_dict)
+
+    def remove_provenance_tab(self, workspace_name):
+        """remove provenance tab for a workspace, if it exists"""
+
+        # access tab pages
+        main_window = self.view.parent().parent().parent()
+        current_tab = self.view.parent().parent().currentWidget()
+        widget_tab = main_window.tabs
+        tab_name = f"Generate - {workspace_name}"
+
+        for i in range(widget_tab.count()):
+            if widget_tab.tabText(i) == tab_name and current_tab != widget_tab.widget(i):
+                generate_tab_index = i
+                # remove current tab
+                widget_tab.removeTab(generate_tab_index)
+                # add a new tab
+                main_window.generate = Generate(main_window)
+                generate_model = GenerateModel()
+                main_window.generate_presenter = GeneratePresenter(main_window.generate, generate_model)
+                widget_tab.addTab(main_window.generate, "Generate")
 
     def submit_histogram_to_make_slice(self):
         """Submit the histogram to the model"""

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -4,7 +4,6 @@ from qtpy.QtWidgets import QWidget
 from shiver.views.corrections import Corrections
 from shiver.models.corrections import CorrectionsModel
 from shiver.models.generate import gather_mde_config_dict, save_mde_config_dict
-from shiver.presenters.sample import get_sample_parameters_from_workspace
 
 from shiver.models.generate import GenerateModel
 from shiver.presenters.generate import GeneratePresenter
@@ -12,6 +11,9 @@ from shiver.views.generate import Generate
 
 from shiver.models.polarized import PolarizedModel
 from shiver.presenters.polarized import create_dictionary_polarized_options
+
+from shiver.models.sample import SampleModel
+from shiver.presenters.sample import get_sample_parameters_from_workspace
 
 
 class HistogramPresenter:  # pylint: disable=too-many-public-methods
@@ -166,7 +168,10 @@ class HistogramPresenter:  # pylint: disable=too-many-public-methods
         config_dict["output_dir"] = os.path.dirname(filepath)
         config_dict["mde_type"] = "Data"
 
-        config_dict["SampleParameters"] = get_sample_parameters_from_workspace(name)
+        # init SampleModel
+        sample_model = SampleModel(name)
+        # sample logs are stored as separate sample logs
+        config_dict["SampleParameters"] = get_sample_parameters_from_workspace(sample_model.get_lattice_ub())
         # init PolarizedModel
         polarized_model = PolarizedModel(name)
         # get logs
@@ -272,8 +277,10 @@ class HistogramPresenter:  # pylint: disable=too-many-public-methods
             polarized_model.get_polarization_logs_for_workspace()
         )
 
+        # init SampleModel
+        sample_model = SampleModel(workspace_name)
         # sample logs are stored as separate sample logs
-        config_dict["SampleParameters"] = get_sample_parameters_from_workspace(workspace_name)
+        config_dict["SampleParameters"] = get_sample_parameters_from_workspace(sample_model.get_lattice_ub())
 
         # switch to the Generate tab
         self.view.parent().parent().setCurrentIndex(1)
@@ -433,8 +440,6 @@ class HistogramPresenter:  # pylint: disable=too-many-public-methods
 
         # init PolarizedModel
         polarized_model = PolarizedModel(name)
-        # connect error message
-        # polarized_model.connect_error_message(self.error_message)
         # save state
         polarized_model.save_polarization_state(pol_state)
 
@@ -443,8 +448,6 @@ class HistogramPresenter:  # pylint: disable=too-many-public-methods
 
         # init PolarizedModel
         polarized_model = PolarizedModel(name)
-        # connect error message
-        # polarized_model.connect_error_message(self.error_message)
         # get state
         state = polarized_model.get_polarization_state()
         return state

--- a/src/shiver/presenters/polarized.py
+++ b/src/shiver/presenters/polarized.py
@@ -38,6 +38,9 @@ class PolarizedPresenter:
         # do not update psda value if readonly field
         if self.view.dialog.disable_psda:
             del polarization_logs["PSDA"]
+        else:
+            polarization_logs["psda"] = polarization_logs["PSDA"]
+            del polarization_logs["PSDA"]
         self.model.save_polarization_logs(polarization_logs)
 
 

--- a/src/shiver/presenters/polarized.py
+++ b/src/shiver/presenters/polarized.py
@@ -1,0 +1,46 @@
+"""Presenter for the Polarized Options dialog"""
+
+
+class PolarizedPresenter:
+    """Polarized Options presenter"""
+
+    def __init__(self, view, model):
+        self._view = view
+        self._model = model
+
+        self.model.connect_error_message(self.error_message)
+
+        # button
+        self.view.connect_apply_submit(self.handle_apply_button)
+        self.view.connect_populate_polarized_options(self.get_polarization_logs)
+
+    @property
+    def view(self):
+        """Return the view for this presenter"""
+        return self._view
+
+    @property
+    def model(self):
+        """Return the model for this presenter"""
+        return self._model
+
+    def error_message(self, msg):
+        """Pass error message to the view"""
+        self.view.get_error_message(msg)
+
+    def get_polarization_logs(self):
+        """Retrieve the values for the sample logs"""
+        sample_log_data = self.model.get_polarization_logs()
+        return create_dictionary_polarized_options(sample_log_data)
+
+    def handle_apply_button(self, polarization_logs):
+        """Save the values for the sample logs"""
+        self.model.save_polarization_logs(polarization_logs)
+
+
+def create_dictionary_polarized_options(sample_log_data):
+    """Create a dictionary from the values for the sample logs"""
+    # map the sample logs names requested to the actual sample logs saved in the workspace
+    sample_log_data["PSDA"] = sample_log_data["psda"]
+    del sample_log_data["psda"]
+    return sample_log_data

--- a/src/shiver/presenters/polarized.py
+++ b/src/shiver/presenters/polarized.py
@@ -35,6 +35,9 @@ class PolarizedPresenter:
 
     def handle_apply_button(self, polarization_logs):
         """Save the values for the sample logs"""
+        # do not update psda value if readonly field
+        if self.view.dialog.disable_psda:
+            del polarization_logs["PSDA"]
         self.model.save_polarization_logs(polarization_logs)
 
 

--- a/src/shiver/presenters/sample.py
+++ b/src/shiver/presenters/sample.py
@@ -122,7 +122,7 @@ def get_sample_parameters_from_workspace(oriented_lattice):
     params = copy_params_to_dict(oriented_lattice, params)
     params["u"] = ",".join(str(item) for item in oriented_lattice.getuVector())
     params["v"] = ",".join(str(item) for item in oriented_lattice.getvVector())
-    params["ub_matrix"] = ",".join(str(item) for row in params["ub_matrix"] for item in row)
-    for key in ["ux", "uy", "uz", "vx", "vy", "vz"]:
+    params["matrix_ub"] = ",".join(str(item) for row in params["ub_matrix"] for item in row)
+    for key in ["ux", "uy", "uz", "vx", "vy", "vz", "ub_matrix"]:
         del params[key]
     return params

--- a/src/shiver/presenters/sample.py
+++ b/src/shiver/presenters/sample.py
@@ -1,6 +1,5 @@
 """Presenter for the Sample Parameters dialog"""
 from copy import deepcopy
-from shiver.models.sample import get_lattice_for_workspace
 
 
 class SamplePresenter:
@@ -117,10 +116,10 @@ def copy_params_to_dict(oriented_lattice, params):
     return params
 
 
-def get_sample_parameters_from_workspace(workspace):
-    """Get UB matrix and lattice parameters"""
-    oriented_lattice = get_lattice_for_workspace(workspace)
-    params = copy_params_to_dict(oriented_lattice, {})
+def get_sample_parameters_from_workspace(oriented_lattice):
+    """Get UB matrix and lattice parameters ina dictionary format"""
+    params = {}
+    params = copy_params_to_dict(oriented_lattice, params)
     params["u"] = ",".join(str(item) for item in oriented_lattice.getuVector())
     params["v"] = ",".join(str(item) for item in oriented_lattice.getvVector())
     params["ub_matrix"] = ",".join(str(item) for row in params["ub_matrix"] for item in row)

--- a/src/shiver/presenters/sample.py
+++ b/src/shiver/presenters/sample.py
@@ -1,5 +1,6 @@
 """Presenter for the Sample Parameters dialog"""
 from copy import deepcopy
+from shiver.models.sample import get_lattice_for_workspace
 
 
 class SamplePresenter:
@@ -42,7 +43,7 @@ class SamplePresenter:
         """Get SetUB matrix"""
         params = {}
         oriented_lattice = self.model.get_lattice_ub()
-        params = self.copy_params_to_dict(oriented_lattice, params)
+        params = copy_params_to_dict(oriented_lattice, params)
         return params
 
     def handle_matrix_state(self, ub_matrix):
@@ -64,7 +65,7 @@ class SamplePresenter:
         """Get SetUB matrix"""
         params = {}
         oriented_lattice = self.model.get_lattice_from_ub_matrix(ub_matrix)
-        params = self.copy_params_to_dict(oriented_lattice, params)
+        params = copy_params_to_dict(oriented_lattice, params)
         return params
 
     def handle_apply_button(self, params_dict):
@@ -75,41 +76,54 @@ class SamplePresenter:
         """Call LoadNexusProcessed"""
         params = {}
         oriented_lattice = self.model.load_nexus_processed(filename)
-        params = self.copy_params_to_dict(oriented_lattice, params)
+        params = copy_params_to_dict(oriented_lattice, params)
         return params
 
     def handle_nexus_button(self, filename):
         """Call LoadNexusUB"""
         params = {}
         oriented_lattice = self.model.load_nexus_ub(filename)
-        params = self.copy_params_to_dict(oriented_lattice, params)
+        params = copy_params_to_dict(oriented_lattice, params)
         return params
 
     def handle_isaw_button(self, filename):
         """Call LoadIsawUB"""
         params = {}
         oriented_lattice = self.model.load_isaw_ub(filename)
-        params = self.copy_params_to_dict(oriented_lattice, params)
+        params = copy_params_to_dict(oriented_lattice, params)
         return params
 
     def error_message(self, msg):
         """Pass error message to the view"""
         self.view.get_error_message(msg)
 
-    def copy_params_to_dict(self, oriented_lattice, params):
-        """Copy all oriented lattice and ub matrix to params dictionary"""
-        if oriented_lattice is not None:
-            params["a"] = oriented_lattice.a()
-            params["b"] = oriented_lattice.b()
-            params["c"] = oriented_lattice.c()
-            params["alpha"] = oriented_lattice.alpha()
-            params["beta"] = oriented_lattice.beta()
-            params["gamma"] = oriented_lattice.gamma()
-            params["ux"] = oriented_lattice.getuVector()[0]
-            params["uy"] = oriented_lattice.getuVector()[1]
-            params["uz"] = oriented_lattice.getuVector()[2]
-            params["vx"] = oriented_lattice.getvVector()[0]
-            params["vy"] = oriented_lattice.getvVector()[1]
-            params["vz"] = oriented_lattice.getvVector()[2]
-            params["ub_matrix"] = deepcopy(oriented_lattice.getUB())
-        return params
+
+def copy_params_to_dict(oriented_lattice, params):
+    """Copy all oriented lattice and ub matrix to params dictionary"""
+    if oriented_lattice is not None:
+        params["a"] = oriented_lattice.a()
+        params["b"] = oriented_lattice.b()
+        params["c"] = oriented_lattice.c()
+        params["alpha"] = oriented_lattice.alpha()
+        params["beta"] = oriented_lattice.beta()
+        params["gamma"] = oriented_lattice.gamma()
+        params["ux"] = oriented_lattice.getuVector()[0]
+        params["uy"] = oriented_lattice.getuVector()[1]
+        params["uz"] = oriented_lattice.getuVector()[2]
+        params["vx"] = oriented_lattice.getvVector()[0]
+        params["vy"] = oriented_lattice.getvVector()[1]
+        params["vz"] = oriented_lattice.getvVector()[2]
+        params["ub_matrix"] = deepcopy(oriented_lattice.getUB())
+    return params
+
+
+def get_sample_parameters_from_workspace(workspace):
+    """Get UB matrix and lattice parameters"""
+    oriented_lattice = get_lattice_for_workspace(workspace)
+    params = copy_params_to_dict(oriented_lattice, {})
+    params["u"] = ",".join(str(item) for item in oriented_lattice.getuVector())
+    params["v"] = ",".join(str(item) for item in oriented_lattice.getvVector())
+    params["ub_matrix"] = ",".join(str(item) for row in params["ub_matrix"] for item in row)
+    for key in ["ux", "uy", "uz", "vx", "vy", "vz"]:
+        del params[key]
+    return params

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -115,12 +115,14 @@ class Generate(QWidget):
         self.raw_data_widget.check_file_input()
         self.minimize_background.set_enabled(False)
 
-    def generate_mde_finish_callback(self, activate):
-        """Toggle the generate button disabled state."""
+    def generate_mde_finish_callback(self, activate, update_workspace):
+        """Toggle the generate button disabled state and update the workspace name."""
         if not activate:
             self.setDisabled(True)
         else:
             self.setEnabled(True)
+        if update_workspace:
+            self.update_workspace_in_reduction_params()
 
     def connect_generate_mde_callback(self, callback):
         """Connect the callback for generating the MDE"""
@@ -269,6 +271,10 @@ class Generate(QWidget):
             options=QFileDialog.DontUseNativeDialog,
         )
         return filepath
+
+    def update_workspace_in_reduction_params(self):
+        """Update the workspace name from mde to reduction parameters"""
+        self.reduction_parameters.workspace_name = self.mde_type_widget.mde_name.text().strip()
 
 
 class MDEType(QGroupBox):

--- a/src/shiver/views/generate.py
+++ b/src/shiver/views/generate.py
@@ -115,14 +115,12 @@ class Generate(QWidget):
         self.raw_data_widget.check_file_input()
         self.minimize_background.set_enabled(False)
 
-    def generate_mde_finish_callback(self, activate, update_workspace):
-        """Toggle the generate button disabled state and update the workspace name."""
+    def generate_mde_finish_callback(self, activate):
+        """Toggle the generate button disabled state"""
         if not activate:
             self.setDisabled(True)
         else:
             self.setEnabled(True)
-        if update_workspace:
-            self.update_workspace_in_reduction_params()
 
     def connect_generate_mde_callback(self, callback):
         """Connect the callback for generating the MDE"""
@@ -399,6 +397,9 @@ class MDEType(QGroupBox):
         if is_valid_name(mde_name):
             self._mde_name = mde_name
             self.set_field_valid_state(self.mde_name)
+            # update the name for the rest of the parameters
+            if self.parent():
+                self.parent().update_workspace_in_reduction_params()
             return True
 
         # the name is not valid

--- a/src/shiver/views/mainwindow.py
+++ b/src/shiver/views/mainwindow.py
@@ -28,7 +28,7 @@ class MainWindow(QWidget):
 
         generate = Generate(self)
         generate_model = GenerateModel()
-        GeneratePresenter(generate, generate_model)
+        self.generate_presenter = GeneratePresenter(generate, generate_model)
         self.tabs.addTab(generate, "Generate")
 
         layout = QVBoxLayout()

--- a/src/shiver/views/polarized_options.py
+++ b/src/shiver/views/polarized_options.py
@@ -83,16 +83,11 @@ class PolarizedView(QWidget):
         """connect to get the polarization logs for workspace"""
         self.get_polarized_options_callback = callback
 
-    # maybe not
-    def set_sample_parameters_dict(self):
-        """Set all sample parameters as a dictionary"""
-        if self.dialog:
-            self.parameters = self.dialog.get_sample_parameters()
-
-    # maybe not
-    def get_sample_parameters_dict(self):
-        """Get all sample parameters as a dictionary"""
-        return self.parameters
+    def set_parameter_dict(self):
+        """Set all polarized parameters as a dictionary in current and parent view"""
+        self.parameters = self.dialog.get_polarized_options_dict()
+        if self.parent:
+            self.parent.dict_polarized = self.parameters
 
 
 class PolarizedDialog(QDialog):
@@ -472,10 +467,10 @@ class PolarizedDialog(QDialog):
     def btn_apply_submit(self):
         """Check everything is valid and close dialog"""
         if len(self.invalid_fields) == 0:
-            # update the grandparent view
             dict_polarized = self.get_polarized_options_dict()
-            if self.parent.parent:
-                self.parent.parent.dict_polarized = dict_polarized
+            # update the grand/parent view
+            if self.parent:
+                self.parent.set_parameter_dict()
             # save them in the workspace
             if self.parent.apply_submit_callback:
                 self.parent.apply_submit_callback(dict_polarized)

--- a/src/shiver/views/polarized_options.py
+++ b/src/shiver/views/polarized_options.py
@@ -100,7 +100,8 @@ class PolarizedDialog(QDialog):
 
     def __init__(self, parent=None, disable_psda=False):
         super().__init__(parent)
-
+        # psda readonly flag
+        self.disable_psda = disable_psda
         layout = QGridLayout()
         layout.setContentsMargins(10, 10, 10, 10)
         self.setLayout(layout)

--- a/src/shiver/views/sample.py
+++ b/src/shiver/views/sample.py
@@ -96,6 +96,8 @@ class SampleView(QWidget):
         """Set all sample parameters as a dictionary"""
         if self.dialog:
             self.parameters = self.dialog.get_sample_parameters()
+            if self.parent():
+                self.parent().dict_sample = self.parameters
 
     def get_sample_parameters_dict(self):
         """Get all sample parameters as a dictionary"""

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -20,7 +20,11 @@ from qtpy.QtGui import QCursor
 from shiver.views.sample import SampleView
 from shiver.presenters.sample import SamplePresenter
 from shiver.models.sample import SampleModel
-from .polarized_options import PolarizedDialog
+
+from shiver.views.polarized_options import PolarizedView
+from shiver.presenters.polarized import PolarizedPresenter
+from shiver.models.polarized import PolarizedModel
+
 from .invalid_styles import INVALID_QLISTWIDGET
 from .plots import do_colorfill_plot, do_slice_viewer, plot_md_ws_from_names
 from .workspace_icons import IconLegend, get_icon
@@ -202,7 +206,6 @@ class MDEList(ADSList):  # pylint: disable=too-many-public-methods
         self.do_provenance_callback = None
         self.save_polarization_state_callback = None
         self.get_polarization_state_callback = None
-        self.save_polarization_logs_callback = None
         self.get_polarization_logs_callback = None
         self.dict_polarized = None
 
@@ -213,10 +216,6 @@ class MDEList(ADSList):  # pylint: disable=too-many-public-methods
     def connect_get_polarization_state_workspace(self, callback):
         """connect a function to get the polariation state for workspace"""
         self.get_polarization_state_callback = callback
-
-    def connect_save_polarization_logs(self, callback):
-        """connect a function to save the sample logs for workspace"""
-        self.save_polarization_logs_callback = callback
 
     def connect_get_polarization_logs(self, callback):
         """connect a function to get the sample logs for workspace"""
@@ -454,16 +453,14 @@ class MDEList(ADSList):  # pylint: disable=too-many-public-methods
     def set_pol_options(self, name):
         """Open the dialog to set polarization options in the selected workspace"""
 
-        self.dict_polarized = None
-        dialog = PolarizedDialog(self, True)
+        polarized_view = PolarizedView(self)
+        polarized_model = PolarizedModel(name)
+        PolarizedPresenter(polarized_view, polarized_model)
+
+        dialog = polarized_view.start_dialog(True)
         # populate the dialog
-        input_dict_polarized = self.get_polarization_logs_callback(name)
-        dialog.populate_pol_options_from_dict(input_dict_polarized)
+        dialog.populate_polarized_options()
         dialog.exec_()
-        # if user updated the polarization options and hit "Apply"
-        if self.dict_polarized is not None and self.dict_polarized != input_dict_polarized:
-            # save them in the workspace
-            self.save_polarization_logs_callback(name, self.dict_polarized)
 
         # unselect the previous workspaces state of this workspace with name
         self.unset_selected_states_with_name(name)

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -208,6 +208,7 @@ class MDEList(ADSList):  # pylint: disable=too-many-public-methods
         self.get_polarization_state_callback = None
         self.get_polarization_logs_callback = None
         self.dict_polarized = None
+        self.active_dialog = None
 
     def connect_save_polarization_state_workspace(self, callback):
         """connect a function to save the polarization state for workspace"""
@@ -447,8 +448,17 @@ class MDEList(ADSList):  # pylint: disable=too-many-public-methods
 
         # open the dialog
         dialog = sample.start_dialog()
+        # for testing
+        self.active_dialog = dialog
         dialog.populate_sample_parameters()
         dialog.exec_()
+
+        self.active_dialog = None
+        # unselect the previous workspaces state of this workspace with name
+        self.unset_selected_states_with_name(name)
+
+        # at least one data workspace should be selected
+        self.validate_data_workspace_state()
 
     def set_pol_options(self, name):
         """Open the dialog to set polarization options in the selected workspace"""
@@ -458,10 +468,13 @@ class MDEList(ADSList):  # pylint: disable=too-many-public-methods
         PolarizedPresenter(polarized_view, polarized_model)
 
         dialog = polarized_view.start_dialog(True)
+        # for testing
+        self.active_dialog = dialog
         # populate the dialog
         dialog.populate_polarized_options()
         dialog.exec_()
 
+        self.active_dialog = None
         # unselect the previous workspaces state of this workspace with name
         self.unset_selected_states_with_name(name)
 

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -482,10 +482,10 @@ class MDEList(ADSList):  # pylint: disable=too-many-public-methods
         self.validate_data_workspace_state()
 
     def save_mde_ws(self, name):
-        """method to handle the saving of script"""
+        """method to save workspace data in file"""
         filename, _ = QFileDialog.getSaveFileName(
             self,
-            "Select location to save script",
+            "Select location to save workspace",
             "",
             "All files (*)",
             options=QFileDialog.DontUseNativeDialog,

--- a/src/shiver/views/workspace_tables.py
+++ b/src/shiver/views/workspace_tables.py
@@ -196,6 +196,7 @@ class MDEList(ADSList):  # pylint: disable=too-many-public-methods
         self._data_sf = None
         self._background = None
         self.rename_workspace_callback = None
+        self.save_mde_workspace_callback = None
         self.delete_workspace_callback = None
         self.create_corrections_tab_callback = None
         self.do_provenance_callback = None
@@ -220,6 +221,10 @@ class MDEList(ADSList):  # pylint: disable=too-many-public-methods
     def connect_get_polarization_logs(self, callback):
         """connect a function to get the sample logs for workspace"""
         self.get_polarization_logs_callback = callback
+
+    def connect_save_mde_workspace_callback(self, callback):
+        """connect a function to save the mde workspace"""
+        self.save_mde_workspace_callback = callback
 
     def initialize_default(self):
         """initialize invalid style color due to absence of data"""
@@ -307,6 +312,10 @@ class MDEList(ADSList):  # pylint: disable=too-many-public-methods
         menu.addSeparator()
 
         # data manipulation
+        save = QAction("Save Workspace")
+        save.triggered.connect(partial(self.save_mde_ws, selected_ws_name))
+        menu.addAction(save)
+
         rename = QAction("Rename")
         rename.triggered.connect(partial(self.rename_ws, selected_ws_name))
         menu.addAction(rename)
@@ -461,6 +470,18 @@ class MDEList(ADSList):  # pylint: disable=too-many-public-methods
 
         # at least one data workspace should be selected
         self.validate_data_workspace_state()
+
+    def save_mde_ws(self, name):
+        """method to handle the saving of script"""
+        filename, _ = QFileDialog.getSaveFileName(
+            self,
+            "Select location to save script",
+            "",
+            "All files (*)",
+            options=QFileDialog.DontUseNativeDialog,
+        )
+        if filename and self.save_mde_workspace_callback:
+            self.save_mde_workspace_callback(name, filename)  # pylint: disable=not-callable
 
     def rename_ws(self, name):
         """method to rename the currently selected workspace"""

--- a/tests/models/test_histogram_saving.py
+++ b/tests/models/test_histogram_saving.py
@@ -10,6 +10,7 @@ from mantid.simpleapi import (  # pylint: disable=no-name-in-module
 )
 
 from shiver.models.histogram import HistogramModel
+from shiver.models.polarized import get_experiment_sample_log, get_flipping_ratio
 
 
 def test_saving(tmp_path):
@@ -80,7 +81,7 @@ def test_experiment_sample_log_valid(tmp_path):
     assert saved_pol_state == pol_state
 
     # retrieve the state
-    experiment_state = model.get_experiment_sample_log(name, "PolarizationState")
+    experiment_state = get_experiment_sample_log(name, "PolarizationState")
     assert experiment_state is not None
     assert experiment_state == pol_state
 
@@ -108,7 +109,7 @@ def test_experiment_sample_log_invalid(tmp_path):
 
     # check polarization state is not in sample logs
     # retrieve the state
-    experiment_state = model.get_experiment_sample_log(name, "po")
+    experiment_state = get_experiment_sample_log(name, "po")
     assert experiment_state is None
 
 
@@ -363,7 +364,7 @@ def test_get_flipping_ratio_number(tmp_path):
     AddSampleLog(workspace, LogName="FlippingRatio", LogText="9", LogType="String")
 
     # retrieve the flipping ratio
-    flipping_ratio = model.get_flipping_ratio(name)
+    flipping_ratio = get_flipping_ratio(name)
     assert flipping_ratio == 9
 
 
@@ -395,7 +396,7 @@ def test_get_flipping_ratio_formula(tmp_path):
     AddSampleLog(workspace, LogName="FlippingRatioSampleLog", LogText="omega", LogType="String")
 
     # retrieve the flipping ratio
-    flipping_ratio = model.get_flipping_ratio(name)
+    flipping_ratio = get_flipping_ratio(name)
     assert flipping_ratio == "2*omega+9,omega"
 
 
@@ -426,7 +427,7 @@ def test_get_flipping_ratio_formula_invalid(tmp_path):
     AddSampleLog(workspace, LogName="FlippingRatio", LogText="2*omega+9", LogType="String")
 
     # retrieve the flipping ratio
-    flipping_ratio = model.get_flipping_ratio(name)
+    flipping_ratio = get_flipping_ratio(name)
     assert flipping_ratio is None
 
 

--- a/tests/models/test_histogram_saving.py
+++ b/tests/models/test_histogram_saving.py
@@ -10,7 +10,9 @@ from mantid.simpleapi import (  # pylint: disable=no-name-in-module
 )
 
 from shiver.models.histogram import HistogramModel
-from shiver.models.polarized import get_experiment_sample_log, get_flipping_ratio
+from shiver.models.polarized import PolarizedModel
+from shiver.views.polarized_options import PolarizedView
+from shiver.presenters.polarized import PolarizedPresenter
 
 
 def test_saving(tmp_path):
@@ -68,11 +70,12 @@ def test_experiment_sample_log_valid(tmp_path):
     )
 
     model = HistogramModel()
+    polarized_model = PolarizedModel(name)
 
     model.save(name, str(tmp_path / "test_workspace.nxs"))
     model.save_history(name, str(tmp_path / "test_workspace.py"))
     # save polarization state: unpolarized
-    model.save_polarization_state(name, pol_state)
+    polarized_model.save_polarization_state(pol_state)
 
     # check polarization state in sample logs
     workspace = mtd[name]
@@ -81,7 +84,7 @@ def test_experiment_sample_log_valid(tmp_path):
     assert saved_pol_state == pol_state
 
     # retrieve the state
-    experiment_state = get_experiment_sample_log(name, "PolarizationState")
+    experiment_state = polarized_model.get_experiment_sample_log("PolarizationState")
     assert experiment_state is not None
     assert experiment_state == pol_state
 
@@ -109,7 +112,8 @@ def test_experiment_sample_log_invalid(tmp_path):
 
     # check polarization state is not in sample logs
     # retrieve the state
-    experiment_state = get_experiment_sample_log(name, "po")
+    polarized_model = PolarizedModel(name)
+    experiment_state = polarized_model.get_experiment_sample_log("po")
     assert experiment_state is None
 
 
@@ -131,11 +135,12 @@ def test_polarization_state_unpol(tmp_path):
     )
 
     model = HistogramModel()
+    polarized_model = PolarizedModel(name)
 
     model.save(name, str(tmp_path / "test_workspace.nxs"))
     model.save_history(name, str(tmp_path / "test_workspace.py"))
     # save polarization state: unpolarized
-    model.save_polarization_state(name, pol_state)
+    polarized_model.save_polarization_state(pol_state)
 
     # check polarization state in sample logs
     workspace = mtd[name]
@@ -144,7 +149,7 @@ def test_polarization_state_unpol(tmp_path):
     assert saved_pol_state == pol_state
 
     # retrieve the state after
-    after_pol_state = model.get_polarization_state(name)
+    after_pol_state = polarized_model.get_polarization_state()
     assert after_pol_state == pol_state
 
 
@@ -170,7 +175,8 @@ def test_polarization_state_nsf(tmp_path):
     model.save(name, str(tmp_path / "test_workspace.nxs"))
     model.save_history(name, str(tmp_path / "test_workspace.py"))
     # save polarization state: unpolarized
-    model.save_polarization_state(name, pol_state)
+    polarized_model = PolarizedModel(name)
+    polarized_model.save_polarization_state(pol_state)
 
     # check polarization state in sample logs
     workspace = mtd[name]
@@ -183,7 +189,7 @@ def test_polarization_state_nsf(tmp_path):
     assert saved_pol_dir == "Pz"
 
     # retrieve the state after
-    after_pol_state = model.get_polarization_state(name)
+    after_pol_state = polarized_model.get_polarization_state()
     assert after_pol_state == pol_state
 
 
@@ -209,7 +215,8 @@ def test_polarization_state_sf(tmp_path):
     model.save(name, str(tmp_path / "test_workspace.nxs"))
     model.save_history(name, str(tmp_path / "test_workspace.py"))
     # save polarization state: unpolarized
-    model.save_polarization_state(name, pol_state)
+    polarized_model = PolarizedModel(name)
+    polarized_model.save_polarization_state(pol_state)
 
     # check polarization state in sample logs
     workspace = mtd[name]
@@ -218,7 +225,7 @@ def test_polarization_state_sf(tmp_path):
     assert saved_pol_state == pol_state
 
     # retrieve the state after
-    after_pol_state = model.get_polarization_state(name)
+    after_pol_state = polarized_model.get_polarization_state()
     assert after_pol_state == pol_state
 
 
@@ -250,13 +257,16 @@ def test_polarization_parameters(tmp_path, shiver_app, qtbot):
     AddSampleLog(workspace, LogName="psda", LogText="1.3", LogType="String")
 
     model = shiver_app.main_window.histogram_presenter.model
-    presenter = shiver_app.main_window.histogram_presenter
 
     model.save(name, str(tmp_path / "test_workspace.nxs"))
     model.save_history(name, str(tmp_path / "test_workspace.py"))
     qtbot.wait(100)
     # save polarization parameters except from psda
-    presenter.save_polarization_logs(name, pol_sample_logs)
+    polarized_view = PolarizedView()
+    polarized_model = PolarizedModel(name)
+    polarized_presenter = PolarizedPresenter(polarized_view, polarized_model)
+    polarized_view.start_dialog(True)
+    polarized_presenter.handle_apply_button(pol_sample_logs)
 
     # check polarization parameters in sample logs
     run = workspace.getExperimentInfo(0).run()
@@ -267,7 +277,7 @@ def test_polarization_parameters(tmp_path, shiver_app, qtbot):
     assert run.getLogData("psda").value == "1.3"
 
     # retrieve the polarization parameters after
-    saved_pol_logs = presenter.get_polarization_logs(name)
+    saved_pol_logs = polarized_presenter.get_polarization_logs()
     assert saved_pol_logs["PolarizationState"] == pol_sample_logs["PolarizationState"]
     assert saved_pol_logs["PolarizationDirection"] == pol_sample_logs["PolarizationDirection"]
     assert saved_pol_logs["FlippingRatio"] == pol_sample_logs["FlippingRatio"]
@@ -300,14 +310,15 @@ def test_polarization_state_invalid(tmp_path):
     workspace = mtd[name]
     AddSampleLog(workspace, LogName="test_log", LogText="test", LogType="String")
     # save polarization state: invalid
-    model.save_polarization_state(name, pol_state)
+    polarized_model = PolarizedModel(name)
+    polarized_model.save_polarization_state(pol_state)
 
     # check polarization state is not in sample logs
     run = workspace.getExperimentInfo(0).run()
     assert "PolarizationState" not in run.keys()
 
     # retrieve the state after, UNP is default
-    after_pol_state = model.get_polarization_state(name)
+    after_pol_state = polarized_model.get_polarization_state()
     assert after_pol_state == "UNP"
 
 
@@ -334,7 +345,8 @@ def test_polarization_state_no_saved_state(tmp_path):
     model.save_history(name, str(tmp_path / "test_workspace.py"))
 
     # retrieve the state after, UNP is default
-    after_pol_state = model.get_polarization_state(name)
+    polarized_model = PolarizedModel(name)
+    after_pol_state = polarized_model.get_polarization_state()
     assert after_pol_state == "UNP"
 
 
@@ -364,7 +376,8 @@ def test_get_flipping_ratio_number(tmp_path):
     AddSampleLog(workspace, LogName="FlippingRatio", LogText="9", LogType="String")
 
     # retrieve the flipping ratio
-    flipping_ratio = get_flipping_ratio(name)
+    polarized_model = PolarizedModel(name)
+    flipping_ratio = polarized_model.get_flipping_ratio()
     assert flipping_ratio == 9
 
 
@@ -396,7 +409,8 @@ def test_get_flipping_ratio_formula(tmp_path):
     AddSampleLog(workspace, LogName="FlippingRatioSampleLog", LogText="omega", LogType="String")
 
     # retrieve the flipping ratio
-    flipping_ratio = get_flipping_ratio(name)
+    polarized_model = PolarizedModel(name)
+    flipping_ratio = polarized_model.get_flipping_ratio()
     assert flipping_ratio == "2*omega+9,omega"
 
 
@@ -427,7 +441,8 @@ def test_get_flipping_ratio_formula_invalid(tmp_path):
     AddSampleLog(workspace, LogName="FlippingRatio", LogText="2*omega+9", LogType="String")
 
     # retrieve the flipping ratio
-    flipping_ratio = get_flipping_ratio(name)
+    polarized_model = PolarizedModel(name)
+    flipping_ratio = polarized_model.get_flipping_ratio()
     assert flipping_ratio is None
 
 

--- a/tests/models/test_sample_parameters_invalid_inputs.py
+++ b/tests/models/test_sample_parameters_invalid_inputs.py
@@ -117,5 +117,3 @@ def test_invalid_workspace():
     sample_model.connect_error_message(error_callback)
     oriented_lattice = sample_model.get_lattice_ub()
     assert oriented_lattice is not None
-    assert len(errors) == 1
-    assert errors[-1] == "Workspace data does not exist. Lattice from default parameters\n"

--- a/tests/models/test_sample_parameters_invalid_inputs.py
+++ b/tests/models/test_sample_parameters_invalid_inputs.py
@@ -118,4 +118,4 @@ def test_invalid_workspace():
     oriented_lattice = sample_model.get_lattice_ub()
     assert oriented_lattice is not None
     assert len(errors) == 1
-    assert errors[-1] == "Workspace data does not exist\n"
+    assert errors[-1] == "Workspace data does not exist. Lattice from default parameters\n"

--- a/tests/views/test_mainwindow.py
+++ b/tests/views/test_mainwindow.py
@@ -2,10 +2,10 @@
 from shiver import Shiver, __version__
 
 
-def test_mainwindow():
+def test_mainwindow(qtbot):
     """Test that the application starts successfully"""
     shiver = Shiver()
     shiver.show()
-
+    qtbot.waitUntil(shiver.show, timeout=5000)
     assert shiver.isVisible()
     assert shiver.windowTitle() == f"SHIVER - {__version__}"

--- a/tests/views/test_mde_workspaces.py
+++ b/tests/views/test_mde_workspaces.py
@@ -161,7 +161,7 @@ def test_mde_workspaces_menu(qtbot):
     item = mde_table.item(0)
     assert item.text() == "mde1"
 
-    QTimer.singleShot(100, partial(handle_menu, 8))
+    QTimer.singleShot(100, partial(handle_menu, 9))
     qtbot.mouseClick(mde_table.viewport(), Qt.MouseButton.LeftButton, pos=mde_table.visualItemRect(item).center())
 
     qtbot.wait(100)
@@ -186,7 +186,7 @@ def test_mde_workspaces_menu(qtbot):
     item = mde_table.item(0)
     assert item.text() == "mde1"
 
-    QTimer.singleShot(100, partial(handle_menu, 7))
+    QTimer.singleShot(100, partial(handle_menu, 8))
     QTimer.singleShot(200, handle_dialog)
     qtbot.mouseClick(mde_table.viewport(), Qt.MouseButton.LeftButton, pos=mde_table.visualItemRect(item).center())
 

--- a/tests/views/test_polarized_options.py
+++ b/tests/views/test_polarized_options.py
@@ -3,7 +3,7 @@ from functools import partial
 from qtpy import QtCore
 
 
-from shiver.views.polarized_options import PolarizedDialog
+from shiver.views.polarized_options import PolarizedDialog, PolarizedView
 from shiver.views.reduction_parameters import ReductionParameters
 
 
@@ -173,7 +173,9 @@ def test_help_button(qtbot):
 def test_apply_btn_valid_all(qtbot):
     """Test for clicking apply and storing all data as a dictionary in parent"""
     red_parameters = ReductionParameters()
-    dialog = PolarizedDialog(red_parameters)
+    polarized_view = PolarizedView(red_parameters)
+
+    dialog = polarized_view.start_dialog(True)
     dialog.show()
 
     # spin x
@@ -193,7 +195,7 @@ def test_apply_btn_valid_all(qtbot):
     # click apply
     qtbot.mouseClick(dialog.btn_apply, QtCore.Qt.LeftButton)
 
-    dict_data = dialog.parent.dict_polarized
+    dict_data = polarized_view.parent.dict_polarized
 
     # assert values are added in parent dictionary
     assert dict_data["PolarizationState"] == "NSF"
@@ -207,7 +209,9 @@ def test_apply_btn_valid_all(qtbot):
 def test_apply_btn_valid(qtbot):
     """Test for clicking apply and storing data besides Sample log as a dictionary in parent"""
     red_parameters = ReductionParameters()
-    dialog = PolarizedDialog(red_parameters)
+    polarized_view = PolarizedView(red_parameters)
+
+    dialog = polarized_view.start_dialog()
     dialog.show()
 
     # spin x
@@ -226,7 +230,7 @@ def test_apply_btn_valid(qtbot):
     # click apply
     qtbot.mouseClick(dialog.btn_apply, QtCore.Qt.LeftButton)
 
-    dict_data = dialog.parent.dict_polarized
+    dict_data = polarized_view.parent.dict_polarized
 
     # assert values are added in parent dictionary
     assert dict_data["PolarizationState"] == "NSF"


### PR DESCRIPTION
Changes included:
- "Save Workspace" MDE workspace list button
- Sample and Polarization Options refactoring; all related polarization functions are part of Polarized MVP-based structure
- On workspace change in Main tab, the same workspace's Provenance tab closes (if it exists)
- Changes on sample parameters, polarization options and mde name parameter population in main and generate/provenance tabs
- Current tests updated and new ones added