### PR TITLE
Fix log plots

### DIFF
--- a/src/shiver/views/plots.py
+++ b/src/shiver/views/plots.py
@@ -6,9 +6,9 @@ from shiver.configuration import get_data
 
 
 @manage_workspace_names
-def do_1d_plot(workspaces, display_name, intensity_limits=None, log_scale=False):
+def do_1d_plot(workspaces, display_name, intensity_limits=None, log_scale=False, errors=False, overplot=False):
     """Create an 1D plot for the provided workspace"""
-    fig = plot_md_ws_from_names(workspaces, False, False)
+    fig = plot_md_ws_from_names(workspaces, errors, overplot)
     min_limit = intensity_limits["min"] if intensity_limits is not None and "min" in intensity_limits else None
     max_limit = intensity_limits["max"] if intensity_limits is not None and "max" in intensity_limits else None
 

--- a/tests/views/test_mdh_workspaces.py
+++ b/tests/views/test_mdh_workspaces.py
@@ -1,5 +1,6 @@
 """UI tests for the MDH list tables"""
 from functools import partial
+import pytest
 from qtpy.QtWidgets import QApplication, QMenu, QFileDialog, QLineEdit
 from qtpy.QtCore import Qt, QTimer
 from qtpy.QtGui import QContextMenuEvent
@@ -25,7 +26,7 @@ def test_mdh_workspaces_menu(qtbot):
     mdh_table.show()
 
     def mock_call(ws_name, ndims):
-        return f"full {ws_name}: {ndims}", {"min": None, "max": None}
+        return f"{ws_name}: {ndims}", {"min": None, "max": None}
 
     mdh_table.get_display_name_and_intensity_limits = mock_call
 
@@ -127,8 +128,22 @@ def test_mdh_workspaces_menu(qtbot):
     qtbot.wait(100)
 
 
-def test_mdh_plotting_1d(qtbot):
+@pytest.mark.parametrize(
+    "user_conf_file",
+    [
+        """
+        [main_tab.plot]
+        display_title = name_only
+        logarithmic_intensity = True
+    """
+    ],
+    indirect=True,
+)
+def test_mdh_plotting_1d(qtbot, user_conf_file, monkeypatch):
     """Tests the 1D plotting"""
+
+    # mock get_oncat_url, client_id and use_notes info
+    monkeypatch.setattr("shiver.configuration.CONFIG_PATH_FILE", user_conf_file)
 
     # Create workspaces in mantid, needed for plots
     CreateMDHistoWorkspace(
@@ -146,7 +161,7 @@ def test_mdh_plotting_1d(qtbot):
     mdh_table = MDHList()
 
     def mock_call(ws_name, ndims):
-        return f"full {ws_name}: {ndims}", {"min": None, "max": None}
+        return f"{ws_name}: {ndims}", {"min": None, "max": None}
 
     mdh_table.get_display_name_and_intensity_limits = mock_call
 
@@ -173,6 +188,8 @@ def test_mdh_plotting_1d(qtbot):
 
     assert len(figure.axes) == 1
     assert len(figure.axes[0].lines) == 1
+    assert figure.axes[0].get_yscale() == "log"
+    assert figure.axes[0].get_title() == "Plot 1D: 1"
 
     # Select "Overplot 1D"
     QTimer.singleShot(100, partial(handle_menu, qtbot, mdh_table, 2))
@@ -183,6 +200,8 @@ def test_mdh_plotting_1d(qtbot):
     qtbot.wait(500)
 
     assert len(figure.axes[0].lines) == 2
+    assert figure.axes[0].get_yscale() == "log"
+    assert figure.axes[0].get_title() == "Plot 1D: 1"
 
     qtbot.wait(100)
 
@@ -199,6 +218,8 @@ def test_mdh_plotting_1d(qtbot):
 
     assert len(figure2.axes) == 1
     assert len(figure2.axes[0].lines) == 1
+    assert figure.axes[0].get_yscale() == "log"
+    assert figure.axes[0].get_title() == "Plot 1D: 1"
 
     # Select "Overplot 1D with Errors"
     QTimer.singleShot(100, partial(handle_menu, qtbot, mdh_table, 4))
@@ -211,8 +232,22 @@ def test_mdh_plotting_1d(qtbot):
     assert len(figure2.axes[0].lines) == 2
 
 
-def test_mdh_plotting_2d(qtbot):
+@pytest.mark.parametrize(
+    "user_conf_file",
+    [
+        """
+        [main_tab.plot]
+        display_title = name_only
+        logarithmic_intensity = True
+    """
+    ],
+    indirect=True,
+)
+def test_mdh_plotting_2d(qtbot, user_conf_file, monkeypatch):
     """Tests the 2D plotting, colorfill plot or sliceviewer"""
+
+    # mock get_oncat_url, client_id and use_notes info
+    monkeypatch.setattr("shiver.configuration.CONFIG_PATH_FILE", user_conf_file)
     CreateMDHistoWorkspace(
         Dimensionality=4,
         Extents="-10,10,-1,1,-1,1,-2,2",
@@ -228,7 +263,7 @@ def test_mdh_plotting_2d(qtbot):
     mdh_table = MDHList()
 
     def mock_call(ws_name, ndims):
-        return f"full {ws_name}: {ndims}", {"min": None, "max": None}
+        return f"{ws_name}: {ndims}", {"min": None, "max": None}
 
     mdh_table.get_display_name_and_intensity_limits = mock_call
 
@@ -255,6 +290,8 @@ def test_mdh_plotting_2d(qtbot):
     figure = plt.gcf()
     assert len(figure.axes) == 2  # pcolormesh and colorbar
     assert figure.axes[0].pcolormesh
+    assert figure.axes[0].get_title() == "Plot 2D: 2"
+    assert figure.axes[1].get_yscale() == "log"
 
     # sliceviewer
     QTimer.singleShot(100, partial(handle_menu, qtbot, mdh_table, 2))
@@ -268,6 +305,8 @@ def test_mdh_plotting_2d(qtbot):
     slice_viewer = mdh_table.findChild(SliceViewerView)
     assert slice_viewer is not None
     assert slice_viewer.isVisible()
+    assert slice_viewer.data_view.colorbar.norm.currentText() == "Log"
+
     slice_viewer.close()
 
 
@@ -289,7 +328,7 @@ def test_mdh_plotting_3d(qtbot):
     mdh_table = MDHList()
 
     def mock_call(ws_name, ndims):
-        return f"full {ws_name}: {ndims}", {"min": None, "max": None}
+        return f"{ws_name}: {ndims}", {"min": None, "max": None}
 
     mdh_table.get_display_name_and_intensity_limits = mock_call
 

--- a/tests/views/test_mdh_workspaces.py
+++ b/tests/views/test_mdh_workspaces.py
@@ -24,6 +24,11 @@ def test_mdh_workspaces_menu(qtbot):
     qtbot.addWidget(mdh_table)
     mdh_table.show()
 
+    def mock_call(ws_name, ndims):
+        return f"full {ws_name}: {ndims}", {"min": None, "max": None}
+
+    mdh_table.get_display_name_and_intensity_limits = mock_call
+
     mdh_table.add_ws("mdh1", "mdh", "HKL", 1)
     mdh_table.add_ws("mdh2", "mdh", "HKL", 2)
     mdh_table.add_ws("mdh3", "mdh", "HKL", 3)
@@ -139,6 +144,12 @@ def test_mdh_plotting_1d(qtbot):
     )
 
     mdh_table = MDHList()
+
+    def mock_call(ws_name, ndims):
+        return f"full {ws_name}: {ndims}", {"min": None, "max": None}
+
+    mdh_table.get_display_name_and_intensity_limits = mock_call
+
     qtbot.addWidget(mdh_table)
     mdh_table.show()
 
@@ -215,6 +226,12 @@ def test_mdh_plotting_2d(qtbot):
     )
 
     mdh_table = MDHList()
+
+    def mock_call(ws_name, ndims):
+        return f"full {ws_name}: {ndims}", {"min": None, "max": None}
+
+    mdh_table.get_display_name_and_intensity_limits = mock_call
+
     qtbot.addWidget(mdh_table)
     mdh_table.show()
 
@@ -270,6 +287,12 @@ def test_mdh_plotting_3d(qtbot):
     )
 
     mdh_table = MDHList()
+
+    def mock_call(ws_name, ndims):
+        return f"full {ws_name}: {ndims}", {"min": None, "max": None}
+
+    mdh_table.get_display_name_and_intensity_limits = mock_call
+
     qtbot.addWidget(mdh_table)
     mdh_table.show()
 


### PR DESCRIPTION
Fixes [2813](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=2813)

Steps to reproduce:

 1. In your local machine: ~/.shiver/configuration.ini set: display_title = full and/or logarithmic_intensity = True
 1. In the Histogram tab, fill in the parameters to create a histogram (1D or 2D preferably).
 1. Click the"Histogram button". If display_title = full , the plot title contains some extra information on the dimensions. If logarithmic_intensity set to True the plot is show in logarithmic scale
 1. Right-click on the histogram title at the "Histogram data in memory" tab. The same title and/or logarithmic scale does not appear.