### PR TITLE
Use the Optimize instead of Select

### DIFF
--- a/src/shiver/models/refine_ub.py
+++ b/src/shiver/models/refine_ub.py
@@ -12,7 +12,7 @@ from mantid.simpleapi import (  # pylint: disable=no-name-in-module
     mtd,
     CalculateUMatrix,
     FindUBUsingIndexedPeaks,
-    SelectCellOfType,
+    OptimizeLatticeForCellType,
     SetUB,
     SliceMDHisto,
     IndexPeaks,
@@ -125,7 +125,7 @@ class PeaksTableWorkspaceDisplayModel(TableWorkspaceDisplayModel):
         try:
             FindUBUsingIndexedPeaks(subset)
             if lattice_type:
-                SelectCellOfType(subset, CellType=lattice_type, Apply=True)
+                OptimizeLatticeForCellType(subset, CellType=lattice_type, Apply=True)
         except (RuntimeError, ValueError) as err:
             logger.error(str(err))
             if self.error_callback:

--- a/src/shiver/views/refine_ub.py
+++ b/src/shiver/views/refine_ub.py
@@ -165,7 +165,7 @@ class RefineUBView(QWidget):
         plot_layout = QHBoxLayout()
         self.figure, self.axes = plt.subplots(1, 3, subplot_kw={"projection": "mantid"}, figsize=(8, 2))
         self.figure.tight_layout(w_pad=4)
-        self.figure.set_tight_layout(True)
+        self.figure.set_layout_engine('tight')
         self.canvas = FigureCanvas(self.figure)
         plot_layout.addWidget(self.canvas)
         vlayout.addLayout(plot_layout)

--- a/src/shiver/views/refine_ub.py
+++ b/src/shiver/views/refine_ub.py
@@ -165,7 +165,7 @@ class RefineUBView(QWidget):
         plot_layout = QHBoxLayout()
         self.figure, self.axes = plt.subplots(1, 3, subplot_kw={"projection": "mantid"}, figsize=(8, 2))
         self.figure.tight_layout(w_pad=4)
-        self.figure.set_layout_engine('tight')
+        self.figure.set_layout_engine("tight")
         self.canvas = FigureCanvas(self.figure)
         plot_layout.addWidget(self.canvas)
         vlayout.addLayout(plot_layout)

--- a/src/shiver/views/refine_ub.py
+++ b/src/shiver/views/refine_ub.py
@@ -165,6 +165,7 @@ class RefineUBView(QWidget):
         plot_layout = QHBoxLayout()
         self.figure, self.axes = plt.subplots(1, 3, subplot_kw={"projection": "mantid"}, figsize=(8, 2))
         self.figure.tight_layout(w_pad=4)
+        self.figure.set_tight_layout(True)
         self.canvas = FigureCanvas(self.figure)
         plot_layout.addWidget(self.canvas)
         vlayout.addLayout(plot_layout)

--- a/tests/models/test_refine_ub.py
+++ b/tests/models/test_refine_ub.py
@@ -166,9 +166,9 @@ def test_refine_ub_model():
 
     assert peak_table_model.ws.sample().getOrientedLattice().a() == pytest.approx(1)
     assert peak_table_model.ws.sample().getOrientedLattice().b() == pytest.approx(1)
-    assert peak_table_model.ws.sample().getOrientedLattice().c() == pytest.approx(0.99968383)
-    assert peak_table_model.ws.sample().getOrientedLattice().alpha() == pytest.approx(89.99976216)
-    assert peak_table_model.ws.sample().getOrientedLattice().beta() == pytest.approx(89.99987616)
+    assert peak_table_model.ws.sample().getOrientedLattice().c() == pytest.approx(1)
+    assert peak_table_model.ws.sample().getOrientedLattice().alpha() == pytest.approx(90)
+    assert peak_table_model.ws.sample().getOrientedLattice().beta() == pytest.approx(90)
     assert peak_table_model.ws.sample().getOrientedLattice().gamma() == pytest.approx(90)
     assert peak_table_model.ws.sample().getOrientedLattice().getuVector() == pytest.approx([0, 1, 0])
     assert peak_table_model.ws.sample().getOrientedLattice().getvVector() == pytest.approx([0, 0, 1])

--- a/tests/models/test_refine_ub.py
+++ b/tests/models/test_refine_ub.py
@@ -171,4 +171,4 @@ def test_refine_ub_model():
     assert peak_table_model.ws.sample().getOrientedLattice().beta() == pytest.approx(90)
     assert peak_table_model.ws.sample().getOrientedLattice().gamma() == pytest.approx(90)
     assert peak_table_model.ws.sample().getOrientedLattice().getuVector() == pytest.approx([0, 1, 0])
-    assert peak_table_model.ws.sample().getOrientedLattice().getvVector() == pytest.approx([0, 0, 1])
+    assert peak_table_model.ws.sample().getOrientedLattice().getvVector() == pytest.approx([1, 0, 0])

--- a/tests/models/test_refine_ub.py
+++ b/tests/models/test_refine_ub.py
@@ -170,5 +170,5 @@ def test_refine_ub_model():
     assert peak_table_model.ws.sample().getOrientedLattice().alpha() == pytest.approx(90)
     assert peak_table_model.ws.sample().getOrientedLattice().beta() == pytest.approx(90)
     assert peak_table_model.ws.sample().getOrientedLattice().gamma() == pytest.approx(90)
-    assert peak_table_model.ws.sample().getOrientedLattice().getuVector() == pytest.approx([0, 1, 0])
-    assert peak_table_model.ws.sample().getOrientedLattice().getvVector() == pytest.approx([1, 0, 0])
+    assert peak_table_model.ws.sample().getOrientedLattice().getuVector() == pytest.approx([1, 0, 0])
+    assert peak_table_model.ws.sample().getOrientedLattice().getvVector() == pytest.approx([0, 1, 0])

--- a/tests/models/test_refine_ub.py
+++ b/tests/models/test_refine_ub.py
@@ -171,6 +171,4 @@ def test_refine_ub_model():
     assert peak_table_model.ws.sample().getOrientedLattice().beta() == pytest.approx(89.99987616)
     assert peak_table_model.ws.sample().getOrientedLattice().gamma() == pytest.approx(90)
     assert peak_table_model.ws.sample().getOrientedLattice().getuVector() == pytest.approx([0, 1, 0])
-    assert peak_table_model.ws.sample().getOrientedLattice().getvVector() == pytest.approx(
-        [2.16143683e-06, 4.15107836e-06, 0.99968383]
-    )
+    assert peak_table_model.ws.sample().getOrientedLattice().getvVector() == pytest.approx([0, 0, 1])


### PR DESCRIPTION
The correct Mantid algorithm to keep the indexation is OptimizeLatticeForCellType.
Also, from the matplotlib documentation:
```
Note that matplotlib.pyplot.tight_layout() will only adjust the subplot params when it is called. 
In order to perform this adjustment each time the figure is redrawn, you can call fig.set_tight_layout(True)
```