### PR TITLE
Fix 'None' being set as E_max and E_min

### DIFF
--- a/src/shiver/views/advanced_options.py
+++ b/src/shiver/views/advanced_options.py
@@ -654,8 +654,8 @@ class AdvancedDialog(QDialog):  # pylint: disable=too-many-public-methods
         """Populate all fields from dictionary"""
 
         self.set_table_values(params.get("MaskInputs", ""))
-        self.emin_input.setText(str(params.get("E_min", "")))
-        self.emax_input.setText(str(params.get("E_max", "")))
+        self.emin_input.setText(params.get("E_min", ""))
+        self.emax_input.setText(params.get("E_max", ""))
 
         self.filter_check.setChecked(params.get("ApplyFilterBadPulses", False))
 

--- a/tests/models/test_makeslices.py
+++ b/tests/models/test_makeslices.py
@@ -30,7 +30,7 @@ def test_make_slices_invalid():
     )
 
     # case 1. flipping ratio is None
-    with raises(RuntimeError) as excinfo:
+    with raises(TypeError) as excinfo:
         MakeSFCorrectedSlices(
             SFInputWorkspace="sfdata",
             NSFInputWorkspace="nsfdata",
@@ -56,7 +56,7 @@ def test_make_slices_invalid():
 
     assert len(mtd.getObjectNames()) == 2
     assert mtd.getObjectNames() == ["nsfdata", "sfdata"]
-    assert str(excinfo.value).startswith("Some invalid Properties found")
+    assert str(excinfo.value) == "in running MakeSFCorrectedSlices: Some invalid Properties found"
 
     # case 2. flipping ratio is ""
     with raises(ValueError) as excinfo:

--- a/tests/views/test_advanced_options_inputs.py
+++ b/tests/views/test_advanced_options_inputs.py
@@ -523,8 +523,8 @@ def test_advanced_options_initialization_from_dict_e_default():
 
     params = {
         "MaskInputs": table_data,
-        "E_min": "",
-        "E_max": "",
+        "E_min": None,
+        "E_max": None,
         "ApplyFilterBadPulses": False,
         "BadPulsesThreshold": "80",
         "TimeIndepBackgroundWindow": "Default",
@@ -539,8 +539,8 @@ def test_advanced_options_initialization_from_dict_e_default():
         assert dialog.table_view.item(row, 1).text() == params["MaskInputs"][row]["Tube"]
         assert dialog.table_view.item(row, 2).text() == params["MaskInputs"][row]["Pixel"]
 
-    assert dialog.emin_input.text() == params["E_min"]
-    assert dialog.emax_input.text() == params["E_max"]
+    assert dialog.emin_input.text() == ""
+    assert dialog.emax_input.text() == ""
     assert dialog.filter_check.isChecked() is params["ApplyFilterBadPulses"]
     assert dialog.lcutoff_input.text() == params["BadPulsesThreshold"]
     assert dialog.tib_min_input.text() == ""


### PR DESCRIPTION
E_max and E_min are already stored as string in the dict so we don't need to convert back to string, this also fix 'None' being set as the E_max/E_min.

I also updated test_make_slices_invalid after changes from mantidproject/mantid/pull/36563

Fixes [EWM3586](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=3586)

# Short description of the changes:
<!-- Add a concise description here-->

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
