### PR TITLE
Oncat issue

### DIFF
--- a/src/shiver/views/oncat.py
+++ b/src/shiver/views/oncat.py
@@ -412,7 +412,6 @@ def get_dataset_info(  # pylint: disable=too-many-branches
     else:
         projection.append("metadata.entry.daslogs.sequencename")
     datafiles = get_data_from_oncat(login, projection, ipts_number, instrument, facility)
-
     # {"run_num": "locations"}
     lookup_table = {df["indexed"]["run_number"]: df["location"] for df in datafiles}
 

--- a/src/shiver/views/oncat.py
+++ b/src/shiver/views/oncat.py
@@ -419,18 +419,21 @@ def get_dataset_info(  # pylint: disable=too-many-branches
     run_number = np.empty(len(datafiles), dtype="int")
     angle = {}
     sequence = np.empty(len(datafiles), dtype="U50")
-    for idx, datafile in enumerate(datafiles):
-        run_number[idx] = datafile["indexed"]["run_number"]
-        angle[str(run_number[idx])] = (
-            datafile["metadata"]["entry"].get("daslogs", {}).get(angle_pv, {}).get("average_value", np.NaN)
-        )
-        if use_notes:
-            sid = datafile["metadata"]["entry"].get("notes", None)
-        else:
-            sid = datafile["metadata"]["entry"].get("daslogs", {}).get("sequencename", {}).get("value", np.NaN)
-        if isinstance(sid, list):
-            sid = sid[-1]
-        sequence[idx] = sid
+    try:
+        for idx, datafile in enumerate(datafiles):
+            run_number[idx] = datafile["indexed"]["run_number"]
+            angle[str(run_number[idx])] = (
+                datafile["metadata"]["entry"].get("daslogs", {}).get(angle_pv, {}).get("average_value", np.NaN)
+            )
+            if use_notes:
+                sid = datafile["metadata"]["entry"].get("notes", None)
+            else:
+                sid = datafile["metadata"]["entry"].get("daslogs", {}).get("sequencename", {}).get("value", np.NaN)
+            if isinstance(sid, list):
+                sid = sid[-1]
+            sequence[idx] = sid
+    except KeyError:
+        return []
     if dataset_name:
         good_runs = run_number[sequence == dataset_name]
     else:

--- a/tests/views/test_oncat.py
+++ b/tests/views/test_oncat.py
@@ -216,6 +216,7 @@ def test_get_dataset_names_invalid_schema(monkeypatch):
 
 def test_get_dataset_info_empty_metadata(monkeypatch):
     """Use mock to test get_dataset__info with empty metadata."""
+
     def mock_get_data_from_oncat(*args, **kwargs):
         mock_data = [
             {
@@ -230,8 +231,7 @@ def test_get_dataset_info_empty_metadata(monkeypatch):
                 "indexed": {
                     "run_number": 2,
                 },
-                "metadata": {}
-                ,
+                "metadata": {},
             },
         ]
         return mock_data
@@ -240,13 +240,7 @@ def test_get_dataset_info_empty_metadata(monkeypatch):
 
     # test the function
     # specify include_runs=[1,2] so len(good_runs) > 0 to prevent return false positive
-    assert get_dataset_info(
-        login="login",
-        ipts_number="ipts",
-        instrument="inst",
-        include_runs=[1,2]
-    ) == []
-
+    assert get_dataset_info(login="login", ipts_number="ipts", instrument="inst", include_runs=[1, 2]) == []
 
 
 if __name__ == "__main__":

--- a/tests/views/test_oncat.py
+++ b/tests/views/test_oncat.py
@@ -214,5 +214,40 @@ def test_get_dataset_names_invalid_schema(monkeypatch):
     assert get_dataset_names("login", "ipts", "inst", use_notes=False) == []
 
 
+def test_get_dataset_info_empty_metadata(monkeypatch):
+    """Use mock to test get_dataset__info with empty metadata."""
+    def mock_get_data_from_oncat(*args, **kwargs):
+        mock_data = [
+            {
+                "location": "/tmp/a",
+                "indexed": {
+                    "run_number": 1,
+                },
+                "metadata": {},
+            },
+            {
+                "location": "/tmp/b",
+                "indexed": {
+                    "run_number": 2,
+                },
+                "metadata": {}
+                ,
+            },
+        ]
+        return mock_data
+
+    monkeypatch.setattr("shiver.views.oncat.get_data_from_oncat", mock_get_data_from_oncat)
+
+    # test the function
+    # specify include_runs=[1,2] so len(good_runs) > 0 to prevent return false positive
+    assert get_dataset_info(
+        login="login",
+        ipts_number="ipts",
+        instrument="inst",
+        include_runs=[1,2]
+    ) == []
+
+
+
 if __name__ == "__main__":
     pytest.main(["-v", __file__])


### PR DESCRIPTION
# Short description of the changes:
Shiver crashes when selecting i.e. IPTS-4653 due to the "metadata" in datafiles missing keys. The changes wrapped the part of the code that would crashes with try: except commands such that if "metadata"=={} the function returns an empty list. A unit test is also added for this scenario.

# Long description of the changes:

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
