### PR TITLE
Reverse ipts order in the GUI

### DIFF
--- a/src/shiver/views/oncat.py
+++ b/src/shiver/views/oncat.py
@@ -247,6 +247,7 @@ class Oncat(QGroupBox):
             instrument=instrument,
             projection=["facility", "instrument"],
         )
+        # reverse - users complained that it takes too long to scroll to current experiment
         experiments.reverse()
         return list({exp["id"] for exp in experiments})
 

--- a/src/shiver/views/oncat.py
+++ b/src/shiver/views/oncat.py
@@ -247,6 +247,7 @@ class Oncat(QGroupBox):
             instrument=instrument,
             projection=["facility", "instrument"],
         )
+        experiments.reverse()
         return list({exp["id"] for exp in experiments})
 
 

--- a/src/shiver/views/oncat.py
+++ b/src/shiver/views/oncat.py
@@ -205,7 +205,7 @@ class Oncat(QGroupBox):
         )
         # update IPTS list
         self.ipts.clear()
-        self.ipts.addItems(sorted(ipts_list, key=lambda x: int(x.split("-")[1])))
+        self.ipts.addItems(sorted(ipts_list, key=lambda x: int(x.split("-")[1]), reverse=True))
 
     def update_datasets(self):
         """Update dataset list"""

--- a/src/shiver/views/oncat.py
+++ b/src/shiver/views/oncat.py
@@ -247,7 +247,6 @@ class Oncat(QGroupBox):
             instrument=instrument,
             projection=["facility", "instrument"],
         )
-        experiments.reverse()
         return list({exp["id"] for exp in experiments})
 
 

--- a/tests/views/test_oncat.py
+++ b/tests/views/test_oncat.py
@@ -56,7 +56,7 @@ def test_oncat(monkeypatch, qtbot):
     # test connect status check
     assert oncat.connected_to_oncat is True
     # test get_suggested_path
-    assert oncat.get_suggested_path() == "/SNS/ARCS/IPTS-1111/nexus"
+    assert oncat.get_suggested_path() == "/SNS/ARCS/IPTS-2222/nexus"
     # test get_suggested_selected_files
     # case 1: no suggestion
     oncat.dataset.setCurrentText("custom")
@@ -70,12 +70,12 @@ def test_oncat(monkeypatch, qtbot):
     # test active connect to oncat
     oncat.connect_to_oncat()
     # test as_dict
-    assert oncat.as_dict() == {"angle_target": 0.1, "dataset": "custom", "instrument": "ARCS", "ipts": "IPTS-1111"}
+    assert oncat.as_dict() == {"angle_target": 0.1, "dataset": "custom", "instrument": "ARCS", "ipts": "IPTS-2222"}
     # test populate from dict
-    oncat.populate_from_dict({"angle_target": 0.2, "dataset": "custom", "instrument": "HYSPEC", "ipts": "IPTS-1111"})
+    oncat.populate_from_dict({"angle_target": 0.2, "dataset": "custom", "instrument": "HYSPEC", "ipts": "IPTS-2222"})
     assert oncat.angle_target.value() == 0.2
     # test get_ipts
-    assert oncat.get_ipts() == "IPTS-1111"
+    assert oncat.get_ipts() == "IPTS-2222"
     # test get_dataset
     assert oncat.get_dataset() == "custom"
     # test get_instrument


### PR DESCRIPTION
# Short description of the changes:
Users complained that it takes too long to go to the current IPTS

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
