### PR TITLE
Navigation toolbar added in figure

### DIFF
--- a/src/shiver/views/refine_ub.py
+++ b/src/shiver/views/refine_ub.py
@@ -15,6 +15,8 @@ from qtpy.QtWidgets import (
 from qtpy.QtCore import Qt, QAbstractTableModel, QModelIndex
 
 from matplotlib.backends.backend_qtagg import FigureCanvas  # pylint: disable=no-name-in-module
+from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
+
 import matplotlib.pyplot as plt
 
 
@@ -199,6 +201,7 @@ class RefineUBView(QWidget):
         self.figure.tight_layout(w_pad=4)
         self.figure.set_layout_engine("tight")
         self.canvas = FigureCanvas(self.figure)
+        self.toolbar = NavigationToolbar(self.canvas)
         plot_layout.addWidget(self.canvas)
         vlayout.addLayout(plot_layout)
 


### PR DESCRIPTION
# Short description of the changes:
There was an issue when Shiver was started through Mantidworkbench related to right plots in refine ub tab.

# Long description of the changes:
The code defines (maintains a link of) NavigationToolbar.  This resolves the Runtime Errors that would appear in console and Mantidworkbench, where users hover on the refine ub's (3 right) plots.

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
(Defect 5317)[https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/5317]
