### PR TITLE
Fix errors in handling pause, and MD workspaces with no UB

### DIFF
--- a/src/shiver/models/convert_dgs_to_single_mde.py
+++ b/src/shiver/models/convert_dgs_to_single_mde.py
@@ -296,11 +296,9 @@ class ConvertDGSToSingleMDE(PythonAlgorithm):
 
         # do filtering
         if units == "TOF" and len(CheckForSampleLogs(Workspace=data, LogNames="pause")) == 0:
-            data = FilterByLogValue(InputWorkspace=data,
-                                    LogName="pause",
-                                    MinimumValue=-1,
-                                    MaximumValue=0.5,
-                                    LogBoundary='Left')
+            data = FilterByLogValue(
+                InputWorkspace=data, LogName="pause", MinimumValue=-1, MaximumValue=0.5, LogBoundary="Left"
+            )
         if units == "TOF" and bad_pulses_threshold > 0:
             data = FilterBadPulses(InputWorkspace=data, LowerCutoff=bad_pulses_threshold)
 

--- a/src/shiver/models/convert_dgs_to_single_mde.py
+++ b/src/shiver/models/convert_dgs_to_single_mde.py
@@ -296,7 +296,11 @@ class ConvertDGSToSingleMDE(PythonAlgorithm):
 
         # do filtering
         if units == "TOF" and len(CheckForSampleLogs(Workspace=data, LogNames="pause")) == 0:
-            data = FilterByLogValue(InputWorkspace=data, LogName="pause", MinimumValue=-1, MaximumValue=0.5)
+            data = FilterByLogValue(InputWorkspace=data,
+                                    LogName="pause",
+                                    MinimumValue=-1,
+                                    MaximumValue=0.5,
+                                    LogBoundary='Left')
         if units == "TOF" and bad_pulses_threshold > 0:
             data = FilterBadPulses(InputWorkspace=data, LowerCutoff=bad_pulses_threshold)
 

--- a/src/shiver/models/sample.py
+++ b/src/shiver/models/sample.py
@@ -45,7 +45,9 @@ class SampleModel:
                 err_msg = f"Workspace {self.name} does not exist. Lattice from default parameters\n"
                 logger.error(err_msg)
             except RuntimeError:
-                err_msg = f"Workspace {self.name} does not contain an OrientedLattice. Lattice from default parameters\n"
+                err_msg = (
+                    f"Workspace {self.name} does not contain an OrientedLattice. Lattice from default parameters\n"
+                )
                 logger.error(err_msg)
         # no valid name-workspace provided, create lattice with initial params
         params = {

--- a/src/shiver/models/sample.py
+++ b/src/shiver/models/sample.py
@@ -45,8 +45,7 @@ class SampleModel:
                 err_msg = f"Workspace {self.name} does not exist. Lattice from default parameters\n"
                 logger.error(err_msg)
             except RuntimeError:
-                err_msg = f"Workspace {self.name} does not contain an OrientedLattice."
-                          " Lattice from default parameters\n"
+                err_msg = f"Workspace {self.name} does not contain an OrientedLattice. Lattice from default parameters\n"
                 logger.error(err_msg)
         # no valid name-workspace provided, create lattice with initial params
         params = {

--- a/src/shiver/models/sample.py
+++ b/src/shiver/models/sample.py
@@ -38,11 +38,16 @@ class SampleModel:
     def get_lattice_ub(self):
         """return oriented lattice object from mtd - if no name provided initialize lattice"""
         if self.name:
-            if mtd.doesExist(self.name):
-                self.oriented_lattice = mtd[self.name].getExperimentInfo(0).sample().getOrientedLattice()
-                return self.oriented_lattice
-            err_msg = f"Workspace {self.name} does not exist. Lattice from default parameters\n"
-            logger.error(err_msg)
+            try:
+                if mtd.doesExist(self.name):
+                    self.oriented_lattice = mtd[self.name].getExperimentInfo(0).sample().getOrientedLattice()
+                    return self.oriented_lattice
+                err_msg = f"Workspace {self.name} does not exist. Lattice from default parameters\n"
+                logger.error(err_msg)
+            except RuntimeError:
+                err_msg = f"Workspace {self.name} does not contain an OrientedLattice." +
+                          " Lattice from default parameters\n"
+                logger.error(err_msg)
         # no valid name-workspace provided, create lattice with initial params
         params = {
             "a": 1.00000,

--- a/src/shiver/models/sample.py
+++ b/src/shiver/models/sample.py
@@ -45,7 +45,7 @@ class SampleModel:
                 err_msg = f"Workspace {self.name} does not exist. Lattice from default parameters\n"
                 logger.error(err_msg)
             except RuntimeError:
-                err_msg = f"Workspace {self.name} does not contain an OrientedLattice." +
+                err_msg = f"Workspace {self.name} does not contain an OrientedLattice."
                           " Lattice from default parameters\n"
                 logger.error(err_msg)
         # no valid name-workspace provided, create lattice with initial params

--- a/tests/models/test_generatemde.py
+++ b/tests/models/test_generatemde.py
@@ -62,6 +62,7 @@ def test_convert_dgs_to_single_mde_single_qsample():
 
 
 def test_convert_dgs_to_single_pause():
+    """Test for correctly handling pause"""
     raw_data_folder = os.path.join(os.path.dirname(__file__), "../data/raw")
 
     data = LoadEventNexus(os.path.join(raw_data_folder, "HYS_178921.nxs.h5"))

--- a/tests/models/test_generatemde.py
+++ b/tests/models/test_generatemde.py
@@ -65,9 +65,9 @@ def test_convert_dgs_to_single_pause():
     raw_data_folder = os.path.join(os.path.dirname(__file__), "../data/raw")
 
     data = LoadEventNexus(os.path.join(raw_data_folder, "HYS_178921.nxs.h5"))
-    AddTimeSeriesLog(Workspace=data, Name='pause', Time='2017-11-02T01:48:58.543570666', Value=1, Type='int')
+    AddTimeSeriesLog(Workspace=data, Name="pause", Time="2017-11-02T01:48:58.543570666", Value=1, Type="int")
     md_p = ConvertDGSToSingleMDE(InputWorkspace=data, Ei=25.0, T0=112.0, TimeIndependentBackground="Default")
-    assert md_p.getNEvents() == 6140 # the original mde has 23682 events
+    assert md_p.getNEvents() == 6140  # the original mde has 23682 events
 
 
 def test_convert_dgs_to_single_mde_single_qlab():

--- a/tests/models/test_generatemde.py
+++ b/tests/models/test_generatemde.py
@@ -23,6 +23,7 @@ from mantid.simpleapi import (  # pylint: disable=no-name-in-module, ungrouped-i
     LoadNexusMonitors,
     GetEiT0atSNS,
     DgsReduction,
+    AddTimeSeriesLog,
     CropWorkspace,
     ConvertToMD,
     ConvertToMDMinMaxGlobal,
@@ -58,6 +59,15 @@ def test_convert_dgs_to_single_mde_single_qsample():
     md2 = ConvertDGSToSingleMDE(InputWorkspace=data, Ei=25.0, T0=112.0, TimeIndependentBackground="Default")
 
     assert CompareMDWorkspaces(md1, md2, IgnoreBoxID=True)[0]
+
+
+def test_convert_dgs_to_single_pause():
+    raw_data_folder = os.path.join(os.path.dirname(__file__), "../data/raw")
+
+    data = LoadEventNexus(os.path.join(raw_data_folder, "HYS_178921.nxs.h5"))
+    AddTimeSeriesLog(Workspace=data, Name='pause', Time='2017-11-02T01:48:58.543570666', Value=1, Type='int')
+    md_p = ConvertDGSToSingleMDE(InputWorkspace=data, Ei=25.0, T0=112.0, TimeIndependentBackground="Default")
+    assert md_p.getNEvents() == 6140 # the original mde has 23682 events
 
 
 def test_convert_dgs_to_single_mde_single_qlab():


### PR DESCRIPTION
# Short description of the changes:
Pause was not handled correctly. In the test it would have killed all events, and it would crash on ConvertToMD.
The sample dialog would crash if no UB is already present in the workspace

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
