### PR TITLE
Fix CI, failing test and missing wheel package

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - pytest=7.2.1
   - pytest-qt=4.2.0
   - pytest-cov=4.0.0
+  - qtpy!=2.4.2
   - setuptools
   - sphinx
   - sphinx-rtd-theme

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - conda-build
   - conda-verify
   - check-wheel-contents
+  - wheel
   - mantidworkbench
   - pre-commit
   - versioningit


### PR DESCRIPTION
The CI currently fails on next, see https://github.com/neutrons/Shiver/actions/runs/12366078528

Test is failing because https://github.com/spyder-ide/qtpy/issues/505 so lets avoid qtpy=2.4.2

I don't know why the wheel package need to be explicitly included when previously it didn't.