### PR TITLE
Oncat connectivity status +configuration mechanism

### DIFF
--- a/src/shiver/configuration_template.ini
+++ b/src/shiver/configuration_template.ini
@@ -2,7 +2,7 @@
 #url to oncat portal
 oncat_url = https://oncat.ornl.gov
 #client id for on cat; it is unique for Shiver
-client_id = 99025bb3-ce06-4f4b-bcf2-36ebf925cd1d
+client_id = 46c478f0-a472-4551-9264-a937626d5fc2
 #the flag (bool: True/False) indicates the location of the names of the datasets (notes/comments vs. sequence name)
 use_notes = False
 
@@ -21,3 +21,8 @@ save_history = True
 
 [global.other]
 help_url = https://neutrons.github.io/Shiver/GUI/
+
+[software.info]
+#software default information
+#version is populated during the creation of the configuration file based on the current software's version
+version = 0.0.0

--- a/src/shiver/presenters/refine_ub.py
+++ b/src/shiver/presenters/refine_ub.py
@@ -38,6 +38,8 @@ class PeaksTableWorkspaceDisplay(TableWorkspaceDisplay):
         self.ads_observer = WorkspaceDisplayADSObserver(self)
         self.presenter.refresh()
         self.container = self
+        # set PeaksTableWorkspaceDisplay group equals to False for newer Mantid versions
+        self.group = False
 
     def emit_close(self):
         """Handle closing"""

--- a/src/shiver/views/oncat.py
+++ b/src/shiver/views/oncat.py
@@ -58,7 +58,9 @@ class Oncat(QGroupBox):
         self.oncat_options_layout.addWidget(self.angle_target_label, 3, 0)
         self.oncat_options_layout.addWidget(self.angle_target, 3, 1)
 
-        self.oncat_login = ONCatLogin(key="shiver", parent=self)
+        client_id = get_data("generate_tab.oncat", "client_id")
+        print("client id", client_id)
+        self.oncat_login = ONCatLogin(key="shiver", client_id=client_id, parent=self)
         self.oncat_login.connection_updated.connect(self.connect_to_oncat)
         self.oncat_options_layout.addWidget(self.oncat_login, 4, 0, 1, 2)
 
@@ -71,18 +73,6 @@ class Oncat(QGroupBox):
         self.use_notes = get_data("generate_tab.oncat", "use_notes")
         # OnCat agent
         self.oncat_agent = self.oncat_login.get_agent_instance()
-
-        # Sync with remote
-        self.sync_with_remote(refresh=True)
-
-        # Sync with remote every 60 seconds
-        # NOTE: make the refresh interval configurable
-        #       in application settings
-        self.update_connection_status_timer = QTimer()
-        self.update_connection_status_timer.timeout.connect(
-            self.sync_with_remote,
-        )
-        self.update_connection_status_timer.start(60_000)
 
         # change in instrument should trigger update of
         # - IPTS
@@ -135,6 +125,11 @@ class Oncat(QGroupBox):
         """Connect to OnCat"""
         # update connection status
         self.sync_with_remote(refresh=True)
+        print("ss", self.oncat_login.status_label.text())
+        # connection status appears for 5 seconds only
+        self.oncat_login.status_label.show()
+        timer = QTimer()
+        timer.singleShot(5000, self.oncat_login.status_label.hide)
 
     def sync_with_remote(self, refresh=False):
         """Update all items within OnCat widget."""

--- a/src/shiver/views/oncat.py
+++ b/src/shiver/views/oncat.py
@@ -87,6 +87,15 @@ class Oncat(QGroupBox):
         # - dataset
         self.ipts.currentTextChanged.connect(self.update_datasets)
 
+        self.show_connection_status_briefly()
+
+    def show_connection_status_briefly(self):
+        """Show connection status for 5 seconds"""
+        # connection status appears for 5 seconds only
+        self.oncat_login.status_label.show()
+        timer = QTimer()
+        timer.singleShot(5000, self.oncat_login.status_label.hide)
+
     @property
     def connected_to_oncat(self) -> bool:
         """Check if connected to OnCat"""
@@ -129,10 +138,7 @@ class Oncat(QGroupBox):
         # update connection status
         self.sync_with_remote(refresh=True)
         print("ss", self.oncat_login.status_label.text())
-        # connection status appears for 5 seconds only
-        self.oncat_login.status_label.show()
-        timer = QTimer()
-        timer.singleShot(5000, self.oncat_login.status_label.hide)
+        self.show_connection_status_briefly()
 
     def sync_with_remote(self, refresh=False):
         """Update all items within OnCat widget."""

--- a/src/shiver/views/oncat.py
+++ b/src/shiver/views/oncat.py
@@ -74,6 +74,9 @@ class Oncat(QGroupBox):
         # OnCat agent
         self.oncat_agent = self.oncat_login.get_agent_instance()
 
+        # Sync with remote
+        self.sync_with_remote(refresh=True)
+
         # change in instrument should trigger update of
         # - IPTS
         # - dataset

--- a/src/shiver/views/oncat.py
+++ b/src/shiver/views/oncat.py
@@ -59,7 +59,6 @@ class Oncat(QGroupBox):
         self.oncat_options_layout.addWidget(self.angle_target, 3, 1)
 
         client_id = get_data("generate_tab.oncat", "client_id")
-        print("client id", client_id)
         self.oncat_login = ONCatLogin(key="shiver", client_id=client_id, parent=self)
         self.oncat_login.connection_updated.connect(self.connect_to_oncat)
         self.oncat_options_layout.addWidget(self.oncat_login, 4, 0, 1, 2)
@@ -137,7 +136,6 @@ class Oncat(QGroupBox):
         """Connect to OnCat"""
         # update connection status
         self.sync_with_remote(refresh=True)
-        print("ss", self.oncat_login.status_label.text())
         self.show_connection_status_briefly()
 
     def sync_with_remote(self, refresh=False):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ import pytest
 from mantidqt.gui_helper import set_matplotlib_backend
 from mantid.simpleapi import mtd
 from shiver import Shiver
+from shiver.version import __version__ as current_version
 
 # make sure matplotlib is correctly set before we run tests
 set_matplotlib_backend()
@@ -32,6 +33,21 @@ def user_conf_file(tmp_path_factory, request):
     # custom configuration file
     config_data = request.param
     user_config = ConfigParser(allow_no_value=True)
+    user_config.read_string(config_data)
+    user_path = os.path.join(tmp_path_factory.mktemp("data"), "test_config.ini")
+    with open(user_path, "w", encoding="utf8") as config_file:
+        user_config.write(config_file)
+    return user_path
+
+
+@pytest.fixture(scope="session")
+def user_conf_file_with_version(tmp_path_factory, request):
+    """Fixture to create a custom configuration file in tmp_path"""
+    # custom configuration file
+    user_config = ConfigParser(allow_no_value=True)
+    # include current version
+    version_block = f"[software.info]\nversion = {current_version}\n"
+    config_data = request.param + version_block
     user_config.read_string(config_data)
     user_path = os.path.join(tmp_path_factory.mktemp("data"), "test_config.ini")
     with open(user_path, "w", encoding="utf8") as config_file:

--- a/tests/views/test_oncat.py
+++ b/tests/views/test_oncat.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # pylint: disable=all
 """Test the views for the ONCat application."""
-from qtpy.QtWidgets import QGroupBox
+from qtpy.QtWidgets import QGroupBox, QLabel
 from qtpy.QtCore import Signal
 import pytest
 from shiver.views.oncat import (
@@ -17,6 +17,7 @@ def test_oncat(monkeypatch, qtbot):
 
     class MockLogin(QGroupBox):
         connection_updated = Signal(bool)
+        status_label = QLabel("Test")
 
         def __init__(self, *args, parent, **kwargs):
             super().__init__(parent=parent)


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
related PR: https://github.com/neutrons/pyoncatqt/pull/9 
oncat connectivity status logic update, configuration mechanism and client id

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->
The code includes the following:
- oncat connectivity status appears only for 5 seconds
- ocan login dialog pops up at button pressing at any time
- client id update
- configuration mechanism with inclusion of version. Version is retrieved from \__version\__ and written to the user's configuration file. If user's version does not exist or different that current software version all configruation variables are updated, else it works as before.
- tests updated/new for the logic
- refine ub update with group attribute, due to Mantid changes

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
[[SHIVER] OnCat -  Connection Status functionality update](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/8985)