### PR TITLE
Generatemde single quotes replaced by double for json

### DIFF
--- a/src/shiver/models/generate_dgs_mde.py
+++ b/src/shiver/models/generate_dgs_mde.py
@@ -239,7 +239,7 @@ class GenerateDGSMDE(PythonAlgorithm):
         mask_btp_inputs = self.getPropertyValue("MaskInputs")
         # check if the string is not empty
         if mask_btp_inputs:
-            btp_pars_list = json.loads(mask_btp_inputs)
+            btp_pars_list = json.loads(mask_btp_inputs.replace("'", '"'))
             # check if the btp_pars_list has items
             if len(btp_pars_list) > 0:
                 if not __mask:

--- a/tests/models/test_generatemde.py
+++ b/tests/models/test_generatemde.py
@@ -114,6 +114,23 @@ def test_convert_dgs_to_single_mde_mask():
     assert md1.getNEvents() == 415
 
 
+def test_convert_dgs_to_single_mde_mask_single_quotes():
+    """Test for MaskWorkspace option ConvertDGSToSingleMDE with single-quouted pixels"""
+
+    raw_data_folder = os.path.join(os.path.dirname(__file__), "../data/raw")
+
+    # custom mask
+    md1 = GenerateDGSMDE(
+        Filenames=os.path.join(raw_data_folder, "HYS_178921.nxs.h5"),
+        MaskInputs="[{'Bank': '1', 'Tube': '1', 'Pixel': '1-8'}]",
+        Ei=25.0,
+        T0=112.0,
+        TimeIndependentBackground="Default",
+    )
+
+    assert md1.getNEvents() == 24750
+
+
 def test_convert_dgs_to_single_mde_mask_empty():
     """Test for MaskInputs empty option ConvertDGSToSingleMDE"""
 


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
singlee quotes in values for json.loads in Generatemde were replaces with double quotes.
test added

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
[[Shiver] Json double quotes in generate mde](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/9467)