### PR TITLE
Grouping runs based on s2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - conda-verify
   - check-wheel-contents
   - wheel
-  - mantidworkbench=6.11.0.3
+  - mantidworkbench >= 6.12.0
   - pre-commit
   - versioningit
   - pylint=2.17.3

--- a/environment.yml
+++ b/environment.yml
@@ -13,7 +13,7 @@ dependencies:
   - conda-verify
   - check-wheel-contents
   - wheel
-  - mantidworkbench>=6.11.0.3
+  - mantidworkbench=6.11.0.3
   - pre-commit
   - versioningit
   - pylint=2.17.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "Spectroscopy Histogram Visualizer for Event Reduction"
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "mantidworkbench >= 6.11",
+    "mantidworkbench == 6.11.0.3",
     "pyoncat ~= 1.6"
 ]
 license = { text = "GPL3.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "Spectroscopy Histogram Visualizer for Event Reduction"
 dynamic = ["version"]
 requires-python = ">=3.10"
 dependencies = [
-    "mantidworkbench == 6.11.0.3",
+    "mantidworkbench >= 6.12",
     "pyoncat ~= 1.6"
 ]
 license = { text = "GPL3.0" }

--- a/tests/views/test_oncat.py
+++ b/tests/views/test_oncat.py
@@ -244,5 +244,158 @@ def test_get_dataset_info_empty_metadata(monkeypatch):
     assert get_dataset_info(login="login", ipts_number="ipts", instrument="inst", include_runs=[1, 2]) == []
 
 
+def test_get_dataset_info_omega_sort(monkeypatch):
+    """Use mock to test get_dataset_info."""
+
+    # monkeypatch get_data_from_oncat
+    def mock_get_data_from_oncat(*args, **kwargs):
+        mock_data = [
+            {
+                "location": "/tmp/a",
+                "indexed": {
+                    "run_number": 1,
+                },
+                "metadata": {"entry": {"daslogs": {"sequencename": {"value": "a"}, "omega": {"average_value": 2.0}}}},
+            },
+            {
+                "location": "/tmp/b",
+                "indexed": {
+                    "run_number": 2,
+                },
+                "metadata": {
+                    "entry": {
+                        "daslogs": {
+                            "sequencename": {"value": "b"},
+                            "omega": {"average_value": 1.0},
+                        }
+                    }
+                },
+            },
+        ]
+        return mock_data
+
+    monkeypatch.setattr("shiver.views.oncat.get_data_from_oncat", mock_get_data_from_oncat)
+
+    # "a"-omega = 2.0 > "b"-omega=1.0. Algo sort this correctly by returning "b" first then "a"
+    assert get_dataset_info(
+        login="login",
+        ipts_number="ipts",
+        instrument="inst",
+        group_by_angle=True,
+        dataset_name=["a", "b"],
+        use_notes=False,
+    ) == [["/tmp/b"], ["/tmp/a"]]
+
+
+def test_get_dataset_info_omega_bin(monkeypatch):
+    """Use mock to test get_dataset_info."""
+
+    # monkeypatch get_data_from_oncat
+    def mock_get_data_from_oncat(*args, **kwargs):
+        mock_data = [
+            {
+                "location": "/tmp/a",
+                "indexed": {
+                    "run_number": 1,
+                },
+                "metadata": {"entry": {"daslogs": {"sequencename": {"value": "a"}, "omega": {"average_value": 1.1}}}},
+            },
+            {
+                "location": "/tmp/b",
+                "indexed": {
+                    "run_number": 2,
+                },
+                "metadata": {
+                    "entry": {
+                        "daslogs": {
+                            "sequencename": {"value": "b"},
+                            "omega": {"average_value": 1.0},
+                        }
+                    }
+                },
+            },
+        ]
+        return mock_data
+
+    monkeypatch.setattr("shiver.views.oncat.get_data_from_oncat", mock_get_data_from_oncat)
+
+    # omega within tolerance (0.5), binned together
+    assert get_dataset_info(
+        login="login",
+        ipts_number="ipts",
+        instrument="inst",
+        group_by_angle=True,
+        dataset_name=["a", "b"],
+        use_notes=False,
+    ) == [["/tmp/a", "/tmp/b"]]
+
+
+def test_get_dataset_info_sort_by_s2(monkeypatch):
+    """Use mock to test get_dataset_info."""
+
+    # monkeypatch get_data_from_oncat
+    def mock_get_data_from_oncat(*args, **kwargs):
+        mock_data = [
+            {
+                "location": "/tmp/a",
+                "indexed": {
+                    "run_number": 1,
+                },
+                "metadata": {
+                    "entry": {
+                        "daslogs": {
+                            "sequencename": {"value": "a"},
+                            "omega": {"average_value": 1.1},
+                            "s2": {"average_value": 30.0},
+                        }
+                    }
+                },
+            },
+            {
+                "location": "/tmp/b",
+                "indexed": {
+                    "run_number": 2,
+                },
+                "metadata": {
+                    "entry": {
+                        "daslogs": {
+                            "sequencename": {"value": "b"},
+                            "omega": {"average_value": 1.0},
+                            "s2": {"average_value": 31.0},
+                        }
+                    }
+                },
+            },
+            {
+                "location": "/tmp/c",
+                "indexed": {
+                    "run_number": 3,
+                },
+                "metadata": {
+                    "entry": {
+                        "daslogs": {
+                            "sequencename": {"value": "c"},
+                            "omega": {"average_value": 3.0},
+                            "s2": {"average_value": 32.0},
+                        }
+                    }
+                },
+            },
+        ]
+        return mock_data
+
+    monkeypatch.setattr("shiver.views.oncat.get_data_from_oncat", mock_get_data_from_oncat)
+
+    # set instrument to "HYS", introduce s2
+    assert get_dataset_info(
+        login="login",
+        ipts_number="ipts",
+        instrument="HYS",
+        group_by_angle=True,
+        dataset_name=["a", "b", "c"],
+        use_notes=False,
+    ) == [["/tmp/a"], ["/tmp/b"], ["/tmp/c"]]
+
+
 if __name__ == "__main__":
     pytest.main(["-v", __file__])

--- a/tests/views/test_oncat.py
+++ b/tests/views/test_oncat.py
@@ -251,21 +251,21 @@ def test_get_dataset_info_omega_sort(monkeypatch):
     def mock_get_data_from_oncat(*args, **kwargs):
         mock_data = [
             {
-                "location": "/tmp/a",
+                "location": "/tmp/a1",
                 "indexed": {
                     "run_number": 1,
                 },
                 "metadata": {"entry": {"daslogs": {"sequencename": {"value": "a"}, "omega": {"average_value": 2.0}}}},
             },
             {
-                "location": "/tmp/b",
+                "location": "/tmp/a2",
                 "indexed": {
                     "run_number": 2,
                 },
                 "metadata": {
                     "entry": {
                         "daslogs": {
-                            "sequencename": {"value": "b"},
+                            "sequencename": {"value": "a"},
                             "omega": {"average_value": 1.0},
                         }
                     }
@@ -282,9 +282,9 @@ def test_get_dataset_info_omega_sort(monkeypatch):
         ipts_number="ipts",
         instrument="inst",
         group_by_angle=True,
-        dataset_name=["a", "b"],
+        dataset_name=["a"],
         use_notes=False,
-    ) == [["/tmp/b"], ["/tmp/a"]]
+    ) == [["/tmp/a2"], ["/tmp/a1"]]
 
 
 def test_get_dataset_info_omega_bin(monkeypatch):
@@ -294,21 +294,30 @@ def test_get_dataset_info_omega_bin(monkeypatch):
     def mock_get_data_from_oncat(*args, **kwargs):
         mock_data = [
             {
-                "location": "/tmp/a",
+                "location": "/tmp/a1",
                 "indexed": {
                     "run_number": 1,
                 },
                 "metadata": {"entry": {"daslogs": {"sequencename": {"value": "a"}, "omega": {"average_value": 1.1}}}},
             },
             {
-                "location": "/tmp/b",
+                "location": "/tmp/a3",
+                "indexed": {
+                    "run_number": 3,
+                },
+                "metadata": {
+                    "entry": {"daslogs": {"sequencename": {"value": "other"}, "omega": {"average_value": 1.1}}}
+                },
+            },
+            {
+                "location": "/tmp/a2",
                 "indexed": {
                     "run_number": 2,
                 },
                 "metadata": {
                     "entry": {
                         "daslogs": {
-                            "sequencename": {"value": "b"},
+                            "sequencename": {"value": "a"},
                             "omega": {"average_value": 1.0},
                         }
                     }
@@ -325,9 +334,9 @@ def test_get_dataset_info_omega_bin(monkeypatch):
         ipts_number="ipts",
         instrument="inst",
         group_by_angle=True,
-        dataset_name=["a", "b"],
+        dataset_name="a",
         use_notes=False,
-    ) == [["/tmp/a", "/tmp/b"]]
+    ) == [["/tmp/a1", "/tmp/a2"]]
 
 
 def test_get_dataset_info_sort_by_s2(monkeypatch):
@@ -359,7 +368,7 @@ def test_get_dataset_info_sort_by_s2(monkeypatch):
                 "metadata": {
                     "entry": {
                         "daslogs": {
-                            "sequencename": {"value": "b"},
+                            "sequencename": {"value": "a"},
                             "omega": {"average_value": 1.0},
                             "s2": {"average_value": 31.0},
                         }
@@ -374,9 +383,24 @@ def test_get_dataset_info_sort_by_s2(monkeypatch):
                 "metadata": {
                     "entry": {
                         "daslogs": {
-                            "sequencename": {"value": "c"},
+                            "sequencename": {"value": "a"},
                             "omega": {"average_value": 3.0},
                             "s2": {"average_value": 32.0},
+                        }
+                    }
+                },
+            },
+            {
+                "location": "/tmp/d",
+                "indexed": {
+                    "run_number": 4,
+                },
+                "metadata": {
+                    "entry": {
+                        "daslogs": {
+                            "sequencename": {"value": "b"},
+                            "omega": {"average_value": 1.1},
+                            "s2": {"average_value": 30.0},
                         }
                     }
                 },
@@ -392,9 +416,18 @@ def test_get_dataset_info_sort_by_s2(monkeypatch):
         ipts_number="ipts",
         instrument="HYS",
         group_by_angle=True,
-        dataset_name=["a", "b", "c"],
+        dataset_name="a",
         use_notes=False,
     ) == [["/tmp/a"], ["/tmp/b"], ["/tmp/c"]]
+
+    assert get_dataset_info(
+        login="login",
+        ipts_number="ipts",
+        instrument="SEQ",
+        group_by_angle=True,
+        dataset_name="a",
+        use_notes=False,
+    ) == [["/tmp/a", "/tmp/b"], ["/tmp/c"]]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
This or fixes the defect of not grouping files based on s2 angle. This only applies to HYSPEC when the detector moves during experiment.

Additional tests were also added to capture this behaviour. 

EWM [9809](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9809)
# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
