### PR TITLE
Debye-waller

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,8 +1,9 @@
-name: shiver
+name: shiver-6122
 channels:
   - conda-forge
   - mantid-ornl
   - mantid
+  - mantid/label/nightly
   - neutrons/label/rc
   - oncat
   - neutrons
@@ -13,7 +14,7 @@ dependencies:
   - conda-verify
   - check-wheel-contents
   - wheel
-  - mantidworkbench >= 6.12.0
+  - mantidworkbench > 6.12.0
   - pre-commit
   - versioningit
   - pylint=2.17.3
@@ -26,6 +27,6 @@ dependencies:
   - sphinx-rtd-theme
   - python-build
   - pyoncat
-  - pyoncatqt >=1.1.0rc1
+  - pyoncatqt >=1.2.0rc1
   - gtk3
   - libstdcxx-ng

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: shiver-6122
+name: shiver
 channels:
   - conda-forge
   - mantid-ornl

--- a/src/shiver/models/corrections.py
+++ b/src/shiver/models/corrections.py
@@ -423,13 +423,13 @@ class CorrectionsModel:
         error: bool = False,
         msg="",
     ) -> None:
-        """Call when MagneticFormFactorCorrectionMD finishes.
+        """Call when DebyeWallerFactorCorrectionMD finishes.
 
         Parameters
         ----------
         ws_name : str
             Workspace name
-        alg : MagneticFormFactorCorrectionMDObserver
+        alg : DebyeWallerFactorCorrectionMDObserver
             Observer
         error : bool, optional
             Error flag, by default False

--- a/src/shiver/models/corrections.py
+++ b/src/shiver/models/corrections.py
@@ -63,7 +63,6 @@ class CorrectionsModel:
             output_ws_name = f"{output_ws_name}_DWF"
         if magentic_structure_factor:
             output_ws_name = f"{output_ws_name}_MSF"
-        print("mode:", output_ws_name)
 
         if detailed_balance:
             self.apply_detailed_balance(
@@ -98,7 +97,6 @@ class CorrectionsModel:
             )
         if debye_waller_factor:
             input_ws_name = ws_name
-            print("debye_waller_factor=", hyspec_polarizer_transmission, detailed_balance, magentic_structure_factor)
             if hyspec_polarizer_transmission or detailed_balance or magentic_structure_factor:
                 # wait for others to finish
                 while self.algorithm_running:
@@ -109,7 +107,6 @@ class CorrectionsModel:
                 u2,
                 output_ws_name,
             )
-            print("debye_waller_factor=", debye_waller_factor)
 
     def apply_detailed_balance(
         self,

--- a/src/shiver/models/corrections.py
+++ b/src/shiver/models/corrections.py
@@ -1,6 +1,8 @@
 """Model for Corrections tab"""
 
 # pylint: disable=no-name-in-module
+# pylint: disable=too-many-branches
+# pylint: disable=invalid-name
 import time
 from typing import Tuple
 from mantid.api import mtd, AlgorithmManager, AlgorithmObserver
@@ -23,6 +25,8 @@ class CorrectionsModel:
         detailed_balance: bool,
         hyspec_polarizer_transmission: bool,
         temperature: str = "",
+        debye_waller_factor: bool = False,
+        u2: str = "",
         magentic_structure_factor: bool = False,
         ion_name: str = "",
     ) -> None:
@@ -55,8 +59,11 @@ class CorrectionsModel:
             output_ws_name = f"{ws_name}_DB"
         if hyspec_polarizer_transmission:
             output_ws_name = f"{output_ws_name}_PT"
+        if debye_waller_factor:
+            output_ws_name = f"{output_ws_name}_DWF"
         if magentic_structure_factor:
             output_ws_name = f"{output_ws_name}_MSF"
+        print("mode:", output_ws_name)
 
         if detailed_balance:
             self.apply_detailed_balance(
@@ -89,6 +96,20 @@ class CorrectionsModel:
                 ion_name,
                 output_ws_name,
             )
+        if debye_waller_factor:
+            input_ws_name = ws_name
+            print("debye_waller_factor=", hyspec_polarizer_transmission, detailed_balance, magentic_structure_factor)
+            if hyspec_polarizer_transmission or detailed_balance or magentic_structure_factor:
+                # wait for others to finish
+                while self.algorithm_running:
+                    time.sleep(0.1)
+                input_ws_name = output_ws_name
+            self.apply_debye_waller_factor_correction(
+                input_ws_name,
+                u2,
+                output_ws_name,
+            )
+            print("debye_waller_factor=", debye_waller_factor)
 
     def apply_detailed_balance(
         self,
@@ -236,6 +257,55 @@ class CorrectionsModel:
                 self.error_callback(str(err))
             self.algorithm_running = False
 
+    def apply_debye_waller_factor_correction(
+        self,
+        ws_name: str,
+        u2: str,
+        output_ws_name: str,
+    ) -> None:
+        """Apply DebyeWallerFactorCorrection to the workspace.
+
+        Parameters
+        ----------
+        ws_name : str
+            Workspace name
+        u2 : str
+            Mean squared displacement
+        output_ws_name : str
+            Output workspace name
+
+        Returns
+        -------
+        None
+        """
+
+        alg_obs = DebyeWallerFactorCorrectionMDObserver(
+            parent=self,
+            ws_name=ws_name,
+        )
+        self.algorithms_observers.add(alg_obs)
+
+        self.algorithm_running = True
+
+        logger.information(f"Applying Debye-Waller Factor Correction with mean squared displacement value {u2}")
+
+        alg = AlgorithmManager.create("DebyeWallerFactorCorrectionMD")
+        alg_obs.observeFinish(alg)
+        alg_obs.observeError(alg)
+
+        alg.initialize()
+        alg.setLogging(False)
+        try:
+            alg.setProperty("InputWorkspace", ws_name)
+            alg.setProperty("MeanSquaredDisplacement", u2)
+            alg.setProperty("OutputWorkspace", output_ws_name)
+            alg.execute()
+        except RuntimeError as err:
+            logger.error(str(err))
+            if self.error_callback:
+                self.error_callback(str(err))
+            self.algorithm_running = False
+
     def connect_error_message(self, callback):
         """Set the callback function for error messages.
 
@@ -349,6 +419,39 @@ class CorrectionsModel:
         self.algorithms_observers.remove(alg)
         self.algorithm_running = False
 
+    def apply_debye_waller_factor_correction_finished(
+        self,
+        ws_name: str,
+        alg: "DebyeWallerFactorCorrectionMDObserver",
+        error: bool = False,
+        msg="",
+    ) -> None:
+        """Call when MagneticFormFactorCorrectionMD finishes.
+
+        Parameters
+        ----------
+        ws_name : str
+            Workspace name
+        alg : MagneticFormFactorCorrectionMDObserver
+            Observer
+        error : bool, optional
+            Error flag, by default False
+        msg : str, optional
+            Error message, by default ""
+
+        Returns
+        -------
+        None
+        """
+        if error:
+            logger.error(f"Error in DebyeWallerFactorCorrectionMD for {ws_name}")
+            if self.error_callback:
+                self.error_callback(msg)
+        else:
+            logger.information(f"Finished DebyeWallerFactorCorrectionMD for {ws_name}")
+        self.algorithms_observers.remove(alg)
+        self.algorithm_running = False
+
     def get_ws_alg_histories(self, ws_name: str) -> list:
         """Get algorithm histories of the workspace.
 
@@ -425,6 +528,26 @@ class CorrectionsModel:
                 return True, alg_history.getPropertyValue("IonName")
         return False, ""
 
+    def has_debye_waller_factor_correction(self, ws_name: str) -> Tuple[bool, str]:
+        """Check if the workspace has DebyeWallerFactorCorrectionMD applied.
+
+        Parameters
+        ----------
+        ws_name : str
+            Workspace name
+
+        Returns
+        -------
+        Tuple[bool, str]
+            True if the workspace has DebyeWallerFactorCorrectionMD applied.
+            Ion name if the workspace has DebyeWallerFactorCorrectionMD applied.
+        """
+        alg_histories = self.get_ws_alg_histories(ws_name)
+        for alg_history in alg_histories:
+            if alg_history.name() == "DebyeWallerFactorCorrectionMD":
+                return True, alg_history.getPropertyValue("MeanSquaredDisplacement")
+        return False, ""
+
 
 class ApplyDetailedBalanceMDObserver(AlgorithmObserver):
     """Observer for ApplyDetailedBalanceMD algorithm"""
@@ -479,6 +602,23 @@ class MagneticFormFactorCorrectionMDObserver(AlgorithmObserver):
     def errorHandle(self, msg):  # pylint: disable=invalid-name
         """Call upon algorithm error"""
         self.parent.apply_magnetic_form_factor_correction_finished(ws_name=self.ws_name, alg=self, error=True, msg=msg)
+
+
+class DebyeWallerFactorCorrectionMDObserver(AlgorithmObserver):
+    """Observer for DebyeWallerFactorCorrectionMD algorithm"""
+
+    def __init__(self, parent, ws_name: str) -> None:
+        super().__init__()
+        self.parent = parent
+        self.ws_name = ws_name
+
+    def finishHandle(self):  # pylint: disable=invalid-name
+        """Call upon algorithm finishing"""
+        self.parent.apply_debye_waller_factor_correction_finished(ws_name=self.ws_name, alg=self, error=False, msg="")
+
+    def errorHandle(self, msg):  # pylint: disable=invalid-name
+        """Call upon algorithm error"""
+        self.parent.apply_debye_waller_factor_correction_finished(ws_name=self.ws_name, alg=self, error=True, msg=msg)
 
 
 def get_ions_list():

--- a/src/shiver/models/histogram.py
+++ b/src/shiver/models/histogram.py
@@ -208,7 +208,8 @@ class HistogramModel:  # pylint: disable=too-many-public-methods
 
     def rename(self, old_name, new_name):
         """Rename the workspace from old_name to new_name"""
-        RenameWorkspace(old_name, new_name)
+        if old_name != new_name:
+            RenameWorkspace(old_name, new_name)
 
     def save(self, ws_name, filename):
         """Save the workspace to Nexus file."""

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -1,5 +1,6 @@
 """Presenter for the Histogram tab"""
 
+# pylint: disable=invalid-name
 import os
 from qtpy.QtWidgets import QWidget
 from shiver.views.corrections import Corrections
@@ -283,6 +284,7 @@ class HistogramPresenter:  # pylint: disable=too-many-public-methods
             has_detailed_balance, temperature = corrections_tab_model.has_apply_detailed_balance(name)
             has_scattered_transmission_correction = corrections_tab_model.has_scattered_transmission_correction(name)
             has_magnetic_form_factor, ion_name = corrections_tab_model.has_magnetic_form_factor_correction(name)
+            has_debye_waller_factor, u2 = corrections_tab_model.has_debye_waller_factor_correction(name)
             if has_detailed_balance:
                 corrections_tab_view.detailed_balance.setChecked(True)
                 corrections_tab_view.temperature.setText(str(temperature))
@@ -298,6 +300,11 @@ class HistogramPresenter:  # pylint: disable=too-many-public-methods
                     corrections_tab_view.ion_name.setCurrentIndex(idx)
                 corrections_tab_view.magnetic_structure_factor.setEnabled(False)
                 corrections_tab_view.ion_name.setEnabled(False)
+            if has_debye_waller_factor:
+                corrections_tab_view.debye_waller_correction.setChecked(True)
+                corrections_tab_view.u2.setText(str(u2))
+                corrections_tab_view.debye_waller_correction.setEnabled(False)
+                corrections_tab_view.u2.setEnabled(False)
 
             # inline functions
             def _apply():
@@ -310,11 +317,18 @@ class HistogramPresenter:  # pylint: disable=too-many-public-methods
                     corrections_tab_view.hyspec_polarizer_transmission.isChecked()
                     and corrections_tab_view.hyspec_polarizer_transmission.isEnabled()
                 )
+                do_debye_waller = (
+                    corrections_tab_view.debye_waller_correction.isChecked()
+                    and corrections_tab_view.debye_waller_correction.isEnabled()
+                )
+                print("presenter:", corrections_tab_view.u2.text(), corrections_tab_view.ion_name.currentText())
                 corrections_tab_model.apply(
                     name,
                     do_detail_balance,
                     do_polarizer_transmission,
                     corrections_tab_view.temperature.text(),
+                    do_debye_waller,
+                    corrections_tab_view.u2.text(),
                     corrections_tab_view.magnetic_structure_factor.isChecked(),
                     corrections_tab_view.ion_name.currentText(),
                 )

--- a/src/shiver/presenters/histogram.py
+++ b/src/shiver/presenters/histogram.py
@@ -321,7 +321,6 @@ class HistogramPresenter:  # pylint: disable=too-many-public-methods
                     corrections_tab_view.debye_waller_correction.isChecked()
                     and corrections_tab_view.debye_waller_correction.isEnabled()
                 )
-                print("presenter:", corrections_tab_view.u2.text(), corrections_tab_view.ion_name.currentText())
                 corrections_tab_model.apply(
                     name,
                     do_detail_balance,

--- a/src/shiver/views/corrections.py
+++ b/src/shiver/views/corrections.py
@@ -14,6 +14,7 @@ from qtpy.QtWidgets import (
     QComboBox,
 )
 from qtpy.QtCore import Qt
+from qtpy.QtGui import QDoubleValidator
 from .invalid_styles import INVALID_QLINEEDIT, INVALID_QCHECKBOX
 
 
@@ -49,6 +50,9 @@ class Corrections(QWidget):
             "polarizer.\n See DgsScatteredTransmissionCorrectionMD algorithm."
         )
 
+        self.u2_validator = QDoubleValidator(bottom=0, parent=self)
+        self.u2_validator.setNotation(QDoubleValidator.StandardNotation)
+
         # debye waller correction (disabled for now)
         self.debye_waller_correction = QCheckBox("Debye-Waller Correction")
         self.debye_waller_correction.setToolTip(
@@ -57,6 +61,7 @@ class Corrections(QWidget):
         self.u2 = QLineEdit()
         self.u2.setToolTip("Mean squared displacement.")
         self.u2.setPlaceholderText("Please provide mean squared displacement value u^2")
+        self.u2.setValidator(self.u2_validator)
         debye_waller_layout = QHBoxLayout()
         debye_waller_layout.addWidget(self.debye_waller_correction)
         debye_waller_layout.addWidget(self.u2)
@@ -140,10 +145,8 @@ class Corrections(QWidget):
         """Validate u2: validate Debye Waller Correction and u^2 combination"""
         self.set_field_valid_state(self.debye_waller_correction)
         self.set_field_valid_state(self.u2)
-        if (
-            (self.debye_waller_correction.isChecked() and len(self.u2.text()) == 0)  # pylint: disable = R0916
-            or (not self.debye_waller_correction.isChecked() and len(self.u2.text()) > 0)
-            or (len(self.u2.text()) > 0 and self.u2.text()[0] == "-")
+        if (self.debye_waller_correction.isChecked() and len(self.u2.text()) == 0) or (  # pylint: disable = R0916
+            not self.debye_waller_correction.isChecked() and len(self.u2.text()) > 0
         ):
             self.set_field_invalid_state(self.debye_waller_correction, INVALID_QCHECKBOX)
             self.set_field_invalid_state(self.u2, INVALID_QLINEEDIT)

--- a/src/shiver/views/corrections.py
+++ b/src/shiver/views/corrections.py
@@ -144,7 +144,6 @@ class Corrections(QWidget):
             (self.debye_waller_correction.isChecked() and len(self.u2.text()) == 0)  # pylint: disable = R0916
             or (not self.debye_waller_correction.isChecked() and len(self.u2.text()) > 0)
             or (len(self.u2.text()) > 0 and self.u2.text()[0] == "-")
-            or (len(self.u2.text()) > 0 and not self.u2.text().isnumeric())
         ):
             self.set_field_invalid_state(self.debye_waller_correction, INVALID_QCHECKBOX)
             self.set_field_invalid_state(self.u2, INVALID_QLINEEDIT)

--- a/tests/models/test_corrections.py
+++ b/tests/models/test_corrections.py
@@ -13,31 +13,33 @@ from mantid.api import PythonAlgorithm, AlgorithmFactory, MatrixWorkspacePropert
 from mantid.kernel import Direction
 import shiver.models.corrections as corrections
 
+
 class DebyeWallerFactorCorrectionMD(PythonAlgorithm):
     """create a dummy function to test if the algorithms has been applied"""
 
     def PyInit(self):
         self.declareProperty("InputWorkspace", "")
         self.declareProperty("MeanSquaredDisplacement", "")
-        self.declareProperty(
-            MatrixWorkspaceProperty("OutputWorkspace", "", direction=Direction.Output))
+        self.declareProperty(MatrixWorkspaceProperty("OutputWorkspace", "", direction=Direction.Output))
 
     def PyExec(self):
         endrange = int(self.getProperty("MeanSquaredDisplacement").value)  # Convert to int
         wspace = WorkspaceFactory.create("Workspace2D", NVectors=1, XLength=endrange, YLength=endrange)
         self.setProperty("OutputWorkspace", wspace)  # Stores the workspace as the given name
 
+
 class MagneticFormFactorCorrectionMD(PythonAlgorithm):
     """create a dummy function to test if the algorithms has been applied"""
+
     def PyInit(self):
         self.declareProperty("InputWorkspace", "")
         self.declareProperty("IonName", "")
-        self.declareProperty(
-            MatrixWorkspaceProperty("OutputWorkspace", "", direction=Direction.Output))
+        self.declareProperty(MatrixWorkspaceProperty("OutputWorkspace", "", direction=Direction.Output))
 
     def PyExec(self):
         wspace = WorkspaceFactory.create("Workspace2D", NVectors=1, XLength=3, YLength=3)
         self.setProperty("OutputWorkspace", wspace)  # Stores the workspace as the given name
+
 
 def test_applied_debye_waller_factor():
     AlgorithmFactory.subscribe(DebyeWallerFactorCorrectionMD)
@@ -46,12 +48,10 @@ def test_applied_debye_waller_factor():
     assert model.has_debye_waller_factor_correction("test")[0]
     assert model.has_debye_waller_factor_correction("test")[1] == "3"
 
+
 def test_applied_magnetic_form_factor():
     AlgorithmFactory.subscribe(MagneticFormFactorCorrectionMD)
     model = corrections.CorrectionsModel()
     model.apply_magnetic_form_factor_correction("doesnotmatter", "Nd3+", "test")
     assert model.has_magnetic_form_factor_correction("test")[0]
     assert model.has_magnetic_form_factor_correction("test")[1] == "Nd3+"
-
-    
-    

--- a/tests/models/test_corrections.py
+++ b/tests/models/test_corrections.py
@@ -1,22 +1,27 @@
 """Test the histogram workspace saving"""
 
-# pylint: disable=too-many-lines
-# Need to import the new algorithms so they are registered with mantid
-import shiver.models.makeslice  # noqa: F401, E402 pylint: disable=unused-import, wrong-import-order
-from mantid.api import PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty, WorkspaceFactory
-from mantid.kernel import Direction
-import shiver.models.corrections as corrections
+# pylint: disable=invalid-name
+from mantid.api import (  # pylint: disable=no-name-in-module
+    PythonAlgorithm,
+    AlgorithmFactory,
+    MatrixWorkspaceProperty,
+    WorkspaceFactory,
+)
+from mantid.kernel import Direction  # pylint: disable=no-name-in-module
+from shiver.models import corrections
 
 
 class DebyeWallerFactorCorrectionMD(PythonAlgorithm):
     """create a dummy function to test if the algorithms has been applied"""
 
     def PyInit(self):
+        """init"""
         self.declareProperty("InputWorkspace", "")
         self.declareProperty("MeanSquaredDisplacement", "")
         self.declareProperty(MatrixWorkspaceProperty("OutputWorkspace", "", direction=Direction.Output))
 
     def PyExec(self):
+        """execute"""
         endrange = int(self.getProperty("MeanSquaredDisplacement").value)  # Convert to int
         wspace = WorkspaceFactory.create("Workspace2D", NVectors=1, XLength=endrange, YLength=endrange)
         self.setProperty("OutputWorkspace", wspace)  # Stores the workspace as the given name
@@ -26,16 +31,19 @@ class MagneticFormFactorCorrectionMD(PythonAlgorithm):
     """create a dummy function to test if the algorithms has been applied"""
 
     def PyInit(self):
+        """init"""
         self.declareProperty("InputWorkspace", "")
         self.declareProperty("IonName", "")
         self.declareProperty(MatrixWorkspaceProperty("OutputWorkspace", "", direction=Direction.Output))
 
     def PyExec(self):
+        """execute"""
         wspace = WorkspaceFactory.create("Workspace2D", NVectors=1, XLength=3, YLength=3)
         self.setProperty("OutputWorkspace", wspace)  # Stores the workspace as the given name
 
 
 def test_applied_debye_waller_factor():
+    """test debye-waller is applied"""
     AlgorithmFactory.subscribe(DebyeWallerFactorCorrectionMD)
     model = corrections.CorrectionsModel()
     model.apply_debye_waller_factor_correction("doesnotmatter", "3", "test")
@@ -44,6 +52,7 @@ def test_applied_debye_waller_factor():
 
 
 def test_applied_magnetic_form_factor():
+    """test magnetic form factor is applied"""
     AlgorithmFactory.subscribe(MagneticFormFactorCorrectionMD)
     model = corrections.CorrectionsModel()
     model.apply_magnetic_form_factor_correction("doesnotmatter", "Nd3+", "test")

--- a/tests/models/test_corrections.py
+++ b/tests/models/test_corrections.py
@@ -3,6 +3,7 @@
 # pylint: disable=invalid-name
 # pylint: disable=no-name-in-module
 from mantid.simpleapi import CreateMDWorkspace, FakeMDEventData
+import pytest
 from shiver.models import corrections
 
 
@@ -24,3 +25,22 @@ def test_applied_magnetic_form_factor():
     model.apply_magnetic_form_factor_correction("ws", "Nd3", "test")
     assert model.has_magnetic_form_factor_correction("test")[0]
     assert model.has_magnetic_form_factor_correction("test")[1] == "Nd3"
+    with pytest.raises(ValueError):
+        model.apply_magnetic_form_factor_correction("ws", "wrongIon", "test")
+    with pytest.raises(KeyError):
+        model.apply_magnetic_form_factor_correction_finished(
+            "ws", alg=corrections.MagneticFormFactorCorrectionMDObserver(model, "ws")
+        )
+
+
+def test_applied_debye_waller_factor_error():
+    """test debye-waller is applied"""
+    ws = CreateMDWorkspace(Dimensions="1", Extents="1,4", Names="|Q|", Units="A")
+    FakeMDEventData(ws, UniformParams=-6000)
+    model = corrections.CorrectionsModel()
+    with pytest.raises(ValueError):
+        model.apply_debye_waller_factor_correction("ws", "-3", "test")
+    with pytest.raises(KeyError):
+        model.apply_debye_waller_factor_correction_finished(
+            "ws", alg=corrections.DebyeWallerFactorCorrectionMDObserver(model, "ws")
+        )

--- a/tests/models/test_corrections.py
+++ b/tests/models/test_corrections.py
@@ -49,7 +49,8 @@ def test_applied_debye_waller_factor():
     model.apply_debye_waller_factor_correction("doesnotmatter", "3", "test")
     assert model.has_debye_waller_factor_correction("test")[0]
     assert model.has_debye_waller_factor_correction("test")[1] == "3"
-    AlgorithmFactory.unsubscribe("DebyeWallerFactorCorrectionMD",1)
+    AlgorithmFactory.unsubscribe("DebyeWallerFactorCorrectionMD", 1)
+
 
 def test_applied_magnetic_form_factor():
     """test magnetic form factor is applied"""
@@ -58,4 +59,4 @@ def test_applied_magnetic_form_factor():
     model.apply_magnetic_form_factor_correction("doesnotmatter", "Nd3+", "test")
     assert model.has_magnetic_form_factor_correction("test")[0]
     assert model.has_magnetic_form_factor_correction("test")[1] == "Nd3+"
-    AlgorithmFactory.unsubscribe("MagneticFormFactorCorrectionMD",1)
+    AlgorithmFactory.unsubscribe("MagneticFormFactorCorrectionMD", 1)

--- a/tests/models/test_corrections.py
+++ b/tests/models/test_corrections.py
@@ -1,60 +1,25 @@
 """Test the histogram workspace saving"""
 
 # pylint: disable=invalid-name
-from mantid.api import (  # pylint: disable=no-name-in-module
-    PythonAlgorithm,
-    AlgorithmFactory,
-    MatrixWorkspaceProperty,
-    WorkspaceFactory,
-)
-from mantid.kernel import Direction  # pylint: disable=no-name-in-module
+from mantid.simpleapi import CreateMDWorkspace, FakeMDEventData
 from shiver.models import corrections
-
-
-class DebyeWallerFactorCorrectionMD(PythonAlgorithm):
-    """create a dummy function to test if the algorithms has been applied"""
-
-    def PyInit(self):
-        """init"""
-        self.declareProperty("InputWorkspace", "")
-        self.declareProperty("MeanSquaredDisplacement", "")
-        self.declareProperty(MatrixWorkspaceProperty("OutputWorkspace", "", direction=Direction.Output))
-
-    def PyExec(self):
-        """execute"""
-        endrange = int(self.getProperty("MeanSquaredDisplacement").value)  # Convert to int
-        wspace = WorkspaceFactory.create("Workspace2D", NVectors=1, XLength=endrange, YLength=endrange)
-        self.setProperty("OutputWorkspace", wspace)  # Stores the workspace as the given name
-
-
-class MagneticFormFactorCorrectionMD(PythonAlgorithm):
-    """create a dummy function to test if the algorithms has been applied"""
-
-    def PyInit(self):
-        """init"""
-        self.declareProperty("InputWorkspace", "")
-        self.declareProperty("IonName", "")
-        self.declareProperty(MatrixWorkspaceProperty("OutputWorkspace", "", direction=Direction.Output))
-
-    def PyExec(self):
-        """execute"""
-        wspace = WorkspaceFactory.create("Workspace2D", NVectors=1, XLength=3, YLength=3)
-        self.setProperty("OutputWorkspace", wspace)  # Stores the workspace as the given name
 
 
 def test_applied_debye_waller_factor():
     """test debye-waller is applied"""
-    AlgorithmFactory.subscribe(DebyeWallerFactorCorrectionMD)
+    ws = CreateMDWorkspace(Dimensions="1", Extents="1,4", Names="|Q|", Units="A")
+    FakeMDEventData(ws, UniformParams=-6000)
     model = corrections.CorrectionsModel()
-    model.apply_debye_waller_factor_correction("doesnotmatter", "3", "test")
+    model.apply_debye_waller_factor_correction("ws", "3", "test")
     assert model.has_debye_waller_factor_correction("test")[0]
     assert model.has_debye_waller_factor_correction("test")[1] == "3"
 
 
 def test_applied_magnetic_form_factor():
     """test magnetic form factor is applied"""
-    AlgorithmFactory.subscribe(MagneticFormFactorCorrectionMD)
+    ws = CreateMDWorkspace(Dimensions="1", Extents="1,4", Names="|Q|", Units="A")
+    FakeMDEventData(ws, UniformParams=-6000)
     model = corrections.CorrectionsModel()
-    model.apply_magnetic_form_factor_correction("doesnotmatter", "Nd3+", "test")
+    model.apply_magnetic_form_factor_correction("ws", "Nd3", "test")
     assert model.has_magnetic_form_factor_correction("test")[0]
-    assert model.has_magnetic_form_factor_correction("test")[1] == "Nd3+"
+    assert model.has_magnetic_form_factor_correction("test")[1] == "Nd3"

--- a/tests/models/test_corrections.py
+++ b/tests/models/test_corrections.py
@@ -49,7 +49,6 @@ def test_applied_debye_waller_factor():
     model.apply_debye_waller_factor_correction("doesnotmatter", "3", "test")
     assert model.has_debye_waller_factor_correction("test")[0]
     assert model.has_debye_waller_factor_correction("test")[1] == "3"
-    AlgorithmFactory.unsubscribe("DebyeWallerFactorCorrectionMD", 1)
 
 
 def test_applied_magnetic_form_factor():
@@ -59,4 +58,3 @@ def test_applied_magnetic_form_factor():
     model.apply_magnetic_form_factor_correction("doesnotmatter", "Nd3+", "test")
     assert model.has_magnetic_form_factor_correction("test")[0]
     assert model.has_magnetic_form_factor_correction("test")[1] == "Nd3+"
-    AlgorithmFactory.unsubscribe("MagneticFormFactorCorrectionMD", 1)

--- a/tests/models/test_corrections.py
+++ b/tests/models/test_corrections.py
@@ -1,6 +1,7 @@
 """Test the histogram workspace saving"""
 
 # pylint: disable=invalid-name
+# pylint: disable=no-name-in-module
 from mantid.simpleapi import CreateMDWorkspace, FakeMDEventData
 from shiver.models import corrections
 

--- a/tests/models/test_corrections.py
+++ b/tests/models/test_corrections.py
@@ -49,7 +49,7 @@ def test_applied_debye_waller_factor():
     model.apply_debye_waller_factor_correction("doesnotmatter", "3", "test")
     assert model.has_debye_waller_factor_correction("test")[0]
     assert model.has_debye_waller_factor_correction("test")[1] == "3"
-
+    AlgorithmFactory.unsubscribe("DebyeWallerFactorCorrectionMD",1)
 
 def test_applied_magnetic_form_factor():
     """test magnetic form factor is applied"""
@@ -58,3 +58,4 @@ def test_applied_magnetic_form_factor():
     model.apply_magnetic_form_factor_correction("doesnotmatter", "Nd3+", "test")
     assert model.has_magnetic_form_factor_correction("test")[0]
     assert model.has_magnetic_form_factor_correction("test")[1] == "Nd3+"
+    AlgorithmFactory.unsubscribe("MagneticFormFactorCorrectionMD",1)

--- a/tests/models/test_corrections.py
+++ b/tests/models/test_corrections.py
@@ -1,0 +1,57 @@
+"""Test the histogram workspace saving"""
+
+# pylint: disable=too-many-lines
+import os
+import ast
+import h5py
+import pytest
+import time
+
+# Need to import the new algorithms so they are registered with mantid
+import shiver.models.makeslice  # noqa: F401, E402 pylint: disable=unused-import, wrong-import-order
+from mantid.api import PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty, WorkspaceFactory
+from mantid.kernel import Direction
+import shiver.models.corrections as corrections
+
+class DebyeWallerFactorCorrectionMD(PythonAlgorithm):
+    """create a dummy function to test if the algorithms has been applied"""
+
+    def PyInit(self):
+        self.declareProperty("InputWorkspace", "")
+        self.declareProperty("MeanSquaredDisplacement", "")
+        self.declareProperty(
+            MatrixWorkspaceProperty("OutputWorkspace", "", direction=Direction.Output))
+
+    def PyExec(self):
+        endrange = int(self.getProperty("MeanSquaredDisplacement").value)  # Convert to int
+        wspace = WorkspaceFactory.create("Workspace2D", NVectors=1, XLength=endrange, YLength=endrange)
+        self.setProperty("OutputWorkspace", wspace)  # Stores the workspace as the given name
+
+class MagneticFormFactorCorrectionMD(PythonAlgorithm):
+    """create a dummy function to test if the algorithms has been applied"""
+    def PyInit(self):
+        self.declareProperty("InputWorkspace", "")
+        self.declareProperty("IonName", "")
+        self.declareProperty(
+            MatrixWorkspaceProperty("OutputWorkspace", "", direction=Direction.Output))
+
+    def PyExec(self):
+        wspace = WorkspaceFactory.create("Workspace2D", NVectors=1, XLength=3, YLength=3)
+        self.setProperty("OutputWorkspace", wspace)  # Stores the workspace as the given name
+
+def test_applied_debye_waller_factor():
+    AlgorithmFactory.subscribe(DebyeWallerFactorCorrectionMD)
+    model = corrections.CorrectionsModel()
+    model.apply_debye_waller_factor_correction("doesnotmatter", "3", "test")
+    assert model.has_debye_waller_factor_correction("test")[0]
+    assert model.has_debye_waller_factor_correction("test")[1] == "3"
+
+def test_applied_magnetic_form_factor():
+    AlgorithmFactory.subscribe(MagneticFormFactorCorrectionMD)
+    model = corrections.CorrectionsModel()
+    model.apply_magnetic_form_factor_correction("doesnotmatter", "Nd3+", "test")
+    assert model.has_magnetic_form_factor_correction("test")[0]
+    assert model.has_magnetic_form_factor_correction("test")[1] == "Nd3+"
+
+    
+    

--- a/tests/models/test_corrections.py
+++ b/tests/models/test_corrections.py
@@ -1,12 +1,6 @@
 """Test the histogram workspace saving"""
 
 # pylint: disable=too-many-lines
-import os
-import ast
-import h5py
-import pytest
-import time
-
 # Need to import the new algorithms so they are registered with mantid
 import shiver.models.makeslice  # noqa: F401, E402 pylint: disable=unused-import, wrong-import-order
 from mantid.api import PythonAlgorithm, AlgorithmFactory, MatrixWorkspaceProperty, WorkspaceFactory

--- a/tests/models/test_histogram_saving.py
+++ b/tests/models/test_histogram_saving.py
@@ -1641,3 +1641,30 @@ def test_scale_workspace(shiver_app):
     run = mtd[scaled_mde_2].getExperimentInfo(0).run()
     assert "MDScale" in run.keys()
     assert run["MDScale"].value == float(scale_factor) * float(scale_factor_2)
+
+
+def test_rename_workspace(shiver_app):
+    """Test the MDEConfig in save mde workspace."""
+    histogram_presenter = shiver_app.main_window.histogram_presenter
+
+    # clear mantid workspace
+    mtd.clear()
+
+    # load test MD workspace
+    data = "px_mini_SF"
+    LoadMD(
+        Filename=os.path.join(os.path.dirname(os.path.abspath(__file__)), "../data/mde/px_mini_SF.nxs"),
+        OutputWorkspace=data,
+    )
+    config = {}
+    # check original workspace name data = "px_mini_SF"
+    config_data = mtd[data].getExperimentInfo(0).run().getProperty("MDEConfig").value
+    config.update(ast.literal_eval(config_data))
+    assert config["mde_name"] == data
+
+    histogram_presenter.rename_workspace("px_mini_SF", "px_mini_SF_rename")
+    config = {}
+    # get data from new worksapce "px_mini_SF_rename"
+    config_data = mtd["px_mini_SF_rename"].getExperimentInfo(0).run().getProperty("MDEConfig").value
+    config.update(ast.literal_eval(config_data))
+    assert config["mde_name"] == data

--- a/tests/models/test_load.py
+++ b/tests/models/test_load.py
@@ -95,7 +95,7 @@ def test_bad_file(tmp_path):
     assert len(errors) == 2
     assert errors[-1].startswith(
         f"""Error loading {filename} as mde
-ERROR: Kernel::NexusHDF5Descriptor couldn't open hdf5 file {filename} with fapl"""
+ERROR: Kernel::NexusDescriptor couldn't open hdf5 file {filename}"""
     )
 
 

--- a/tests/views/test_correction.py
+++ b/tests/views/test_correction.py
@@ -97,6 +97,10 @@ def test_corrections_table(qtbot, shiver_app):
     corrections_table.magnetic_structure_factor.setChecked(True)
     corrections_table.ion_name.setCurrentIndex(42)  # Hf3
 
+    # test debye-waller factor
+    corrections_table.debye_waller_correction.setChecked(True)
+    corrections_table.u2.setText("1.2")  # <u^2> = 1.2
+
     apply_button = corrections_table.findChild(QWidget, "apply_button")
     assert apply_button.isEnabled() is True
     assert len(corrections_table.invalid_fields) == 0
@@ -104,17 +108,18 @@ def test_corrections_table(qtbot, shiver_app):
     qtbot.wait(100)
 
     # verify corrected workspace is generated
-    assert "data_DB_PT_MSF" in mtd
+    assert "data_DB_PT_DWF_MSF" in mtd
     # verify correct algorithms are called
-    alg_history = mtd["data_DB_PT_MSF"].getHistory().getAlgorithmHistories()
+    alg_history = mtd["data_DB_PT_DWF_MSF"].getHistory().getAlgorithmHistories()
     alg_history_names = [alg.name() for alg in alg_history]
     assert "ApplyDetailedBalanceMD" in alg_history_names
     assert "DgsScatteredTransmissionCorrectionMD" in alg_history_names
     assert "MagneticFormFactorCorrectionMD" in alg_history_names
+    assert "DebyeWallerFactorCorrectionMD" in alg_history_names
 
     # verify history can be reflected in the corrections table
-    mde_list.set_corrections("data_DB_PT_MSF")
-    corrections_table_2 = shiver.main_window.findChild(QWidget, "Corrections - data_DB_PT_MSF")
+    mde_list.set_corrections("data_DB_PT_DWF_MSF")
+    corrections_table_2 = shiver.main_window.findChild(QWidget, "Corrections - data_DB_PT_DWF_MSF")
     assert corrections_table_2 is not None
     assert corrections_table_2.detailed_balance.isChecked()
     assert corrections_table_2.temperature.text() == "SampleTemp"
@@ -126,5 +131,8 @@ def test_corrections_table(qtbot, shiver_app):
 
     assert corrections_table_2.magnetic_structure_factor.isChecked()
     assert corrections_table_2.ion_name.currentText() == "Hf3"
+
+    assert corrections_table_2.debye_waller_correction.isChecked()
+    assert corrections_table_2.u2.text() == "1.2"
     # clean up
     mtd.clear()


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
This PR adds debye-waller factor to shiver. It also fixes a bug where renaming workspace crashes shiver.


EWM [9412](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=9412)

EWM [10033
](https://ornlrse.clm.ibmcloud.com/ccm/web/projects/Neutron%20Data%20Project%20(Change%20Management)#action=com.ibm.team.workitem.viewWorkItem&id=10033)
To test, load some data with quasi-flat excitations and observe that the intensity scales exponentially at increased |Q| based on <U^2>.

![image](https://github.com/user-attachments/assets/7e9a6bf9-24cc-458b-a842-b4996ab702c6)
left side is original data, right side debye-waller normalized.
# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
