### PR TITLE
Mantidworkbench plot error

### DIFF
--- a/src/shiver/views/refine_ub.py
+++ b/src/shiver/views/refine_ub.py
@@ -15,7 +15,7 @@ from qtpy.QtWidgets import (
 from qtpy.QtCore import Qt, QAbstractTableModel, QModelIndex
 
 from matplotlib.backends.backend_qtagg import FigureCanvas  # pylint: disable=no-name-in-module
-import matplotlib.pyplot as plt
+from matplotlib.figure import Figure
 
 
 class PeaksTableModel(QAbstractTableModel):
@@ -195,7 +195,12 @@ class RefineUBView(QWidget):
 
         vlayout = QVBoxLayout()
         plot_layout = QHBoxLayout()
-        self.figure, self.axes = plt.subplots(1, 3, subplot_kw={"projection": "mantid"}, figsize=(8, 2))
+        self.figure = Figure(figsize=(8, 2))
+        # ax1 = self.figure.add_subplot(1, 1)  # Top-left subplot
+        # ax2 = self.figure.add_subplot(1, 2)  # Top-right subplot
+        # ax3 = self.figure.add_subplot(1, 3)
+        self.axes = self.figure.subplots(1, 3, subplot_kw={"projection": "mantid"})
+        # self.figure, self.axes = plt.subplots(1, 3, subplot_kw={"projection": "mantid"}, figsize=(8, 2))
         self.figure.tight_layout(w_pad=4)
         self.figure.set_layout_engine("tight")
         self.canvas = FigureCanvas(self.figure)
@@ -377,3 +382,11 @@ class RefineUBView(QWidget):
                 self.axes[num].set_aspect(1)
 
         self.canvas.draw_idle()
+
+
+# https://github.com/mantidproject/mantid/blob/fa168ec14995d14e42b2ee144a4c868c022bb652/qt/python/mantidqt/mantidqt/widgets/samplelogs/view.py#L29
+
+# from matplotlib.backends import backend_qt4agg  # e.g.
+# backend_qt4agg.new_figure_manager_given_figure(1, fig)
+# fig.show()
+# https://stackoverflow.com/questions/30809316/how-to-create-a-plot-in-matplotlib-without-using-pyplot

--- a/src/shiver/views/refine_ub.py
+++ b/src/shiver/views/refine_ub.py
@@ -196,11 +196,7 @@ class RefineUBView(QWidget):
         vlayout = QVBoxLayout()
         plot_layout = QHBoxLayout()
         self.figure = Figure(figsize=(8, 2))
-        # ax1 = self.figure.add_subplot(1, 1)  # Top-left subplot
-        # ax2 = self.figure.add_subplot(1, 2)  # Top-right subplot
-        # ax3 = self.figure.add_subplot(1, 3)
         self.axes = self.figure.subplots(1, 3, subplot_kw={"projection": "mantid"})
-        # self.figure, self.axes = plt.subplots(1, 3, subplot_kw={"projection": "mantid"}, figsize=(8, 2))
         self.figure.tight_layout(w_pad=4)
         self.figure.set_layout_engine("tight")
         self.canvas = FigureCanvas(self.figure)
@@ -382,11 +378,3 @@ class RefineUBView(QWidget):
                 self.axes[num].set_aspect(1)
 
         self.canvas.draw_idle()
-
-
-# https://github.com/mantidproject/mantid/blob/fa168ec14995d14e42b2ee144a4c868c022bb652/qt/python/mantidqt/mantidqt/widgets/samplelogs/view.py#L29
-
-# from matplotlib.backends import backend_qt4agg  # e.g.
-# backend_qt4agg.new_figure_manager_given_figure(1, fig)
-# fig.show()
-# https://stackoverflow.com/questions/30809316/how-to-create-a-plot-in-matplotlib-without-using-pyplot


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
The code updates the refine_ub figure so the mantid workbench toolbar is not added and thus creating issue.
An indirect test is added that checks the figure's callbacks.

# Long description of the changes:
<!-- Optional, add more details here if the short description is not suffieicnt-->

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
EWM [RuntimeError is displayed in MantidWorkbench, when user hovers on the refine ub's (right 3) plots](https://ornlrse.clm.ibmcloud.com/ccm/resource/itemName/com.ibm.team.workitem.WorkItem/5317)