### PR TITLE
Fix issue with finding Ei/T0 for background

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -2,4 +2,3 @@ ignore:
   -"src/shiver/models/makeslices.py"
   -"src/shiver/models/generate_dgs_mde.py"
   -"src/shiver/models/convert_dgs_to_single_mde.py"
-  

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,4 @@
 ignore:
-  -"src/shiver/models"
+  - "src/shiver/models/makeslices.py"
+  - "src/shiver/models/generate_dgs_mde.py"
+  - "src/shiver/models/convert_dgs_to_single_mde.py"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,2 @@
 ignore:
   -"src/shiver/models"
-  

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,5 @@
+ignore:
+  -"src/shiver/models/makeslices.py"
+  -"src/shiver/models/generate_dgs_mde.py"
+  -"src/shiver/models/convert_dgs_to_single_mde.py"
+  

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,3 @@
 ignore:
-  -"src/shiver/models/makeslices.py"
-  -"src/shiver/models/generate_dgs_mde.py"
-  -"src/shiver/models/convert_dgs_to_single_mde.py"
+  -"src/shiver/models"
+  

--- a/src/shiver/configuration.py
+++ b/src/shiver/configuration.py
@@ -197,6 +197,7 @@ def get_data_logs():
         "psr",
         "s2",
         "msd",
+        "vChTrans",
     ]
 
     if keep_logs is True:

--- a/src/shiver/models/generate_dgs_mde.py
+++ b/src/shiver/models/generate_dgs_mde.py
@@ -289,7 +289,7 @@ class GenerateDGSMDE(PythonAlgorithm):
             for i, f_name in enumerate(filename_nested_list[0]):
                 progress.report(int(endrange * 0.45 * i / len(filename_nested_list)), f"Processing {f_name}")
                 data = LoadEventNexus(f_name, OutputWorkspace=f"__tmp_{i}", AllowList=allowed_logs)
-                Ei, T0 = get_Ei_T0(data, data, cdsm_dict["Ei"], cdsm_dict["T0"], [f_name])
+                Ei, T0 = get_Ei_T0(data, None, cdsm_dict["Ei"], cdsm_dict["T0"], [f_name])
                 e_min = cdsm_dict["EMin"]
                 e_max = cdsm_dict["EMax"]
                 if e_min == Property.EMPTY_DBL:

--- a/tests/models/test_configuration.py
+++ b/tests/models/test_configuration.py
@@ -99,6 +99,7 @@ def test_field_validate_fields_exist(monkeypatch, user_conf_file_with_version):
         "psr",
         "s2",
         "msd",
+        "vChTrans",
     ]
 
 
@@ -175,6 +176,7 @@ def test_keep_logs(monkeypatch, user_conf_file_with_version):
         "psr",
         "s2",
         "msd",
+        "vChTrans",
         "SensorA",
         "SensorB",
     ]


### PR DESCRIPTION
# Short description of the changes:
<!-- Add a concise description here-->
Fixed issues finding Ei/T0

# Long description of the changes:
With keeep_logs configuration set to False, vChTrans log item needed on ARCS and SEQUOIA is missing. Also, in Background minimized by angle and energy, one needs to load the monitors (can only get Ei/T0 from data in case of CNCS and HYSPEC)

To test:

* Generate a 128*8 grouping for ARCS
* Select files ARCS_300975 to 980 in IPTS-34518
* Generate a background minimized by angle and energy

# Check list for the pull request
- [ ] I have read the [CONTRIBUTING]
- [ ] I have read the [CODE_OF_CONDUCT]
- [ ] I have added tests for my changes
- [ ] I have updated the documentation accordingly

# Check list for the reviewer
- [ ] I have read the [CONTRIBUTING]
- [ ] I have verified the proposed changes
- [ ] best software practices
    + [ ] all internal functions have an underbar, as is python standard
    + [ ] clearly named variables (better to be verbose in variable names)
    + [ ] code comments explaining the intent of code blocks
- [ ] All the tests are passing
- [ ] The documentation is up to date
- [ ] code comments added when explaining intent

# Manual test for the reviewer
<!-- Instructions for testing here. -->

# References
<!-- Links to related issues or pull requests -->
<!-- Links to IBM EWM items if aaplicable -->
